### PR TITLE
Feat/common-base-entity-auditing

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/common/config/JpaAuditingConfig.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/common/config/JpaAuditingConfig.java
@@ -1,0 +1,10 @@
+package org.qpeek.qpeek.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+    // TODO: SecurityContext 기반 AuditorAware 적용 예정.
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/common/entity/BaseEntity.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/common/entity/BaseEntity.java
@@ -1,0 +1,23 @@
+package org.qpeek.qpeek.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedBy;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity extends BaseTimeEntity {
+
+    @CreatedBy
+    @Column(name = "created_by", updatable = false) // TODO: AuditAware 구성 이후 NOT NULL 승격 필요
+    private String createdBy;
+
+    @LastModifiedBy
+    @Column(name = "last_modified_by") // TODO: AuditAware 구성 이후 NOT NULL 승격 필요
+    private String lastModifiedBy;
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/common/entity/BaseTimeEntity.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/common/entity/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package org.qpeek.qpeek.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", columnDefinition = "timestamptz", updatable = false, nullable = false)
+    private OffsetDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", columnDefinition = "timestamptz", nullable = false)
+    private OffsetDateTime updatedAt;
+}


### PR DESCRIPTION
### What
- BaseTimeEntity 추가 (`@CreatedDate`, `@LastModifiedDate`)
- BaseEntity (`extends BaseTimeEntity`, `@CreatedBy` , `@LastModifiedBy` ) 
- JPA Auditing 기본 구성 도입
  - AuditorAware는 Security 연동 후 구현 예정


### Why
- 생성/수정 시간 자동 감사 및 추후 사용자 기반 추적 ('createdBy' / 'updatedBy')


### Changes
- `common-entity`: `BaseEntity`, `BaseTimeEntity` 
- `common-config`: `@EnableJpaAuditing` 적용


### Note
- TODO: `AuditorAware<String>` 구현 및 `@EnableJpaAuditing(auditorAwareRef="auditorAware")` 연결
- TODO: AuditorAware 구축 이후  `createdBy`, `lastModifiedBy ` 필드 NOT NULL 승격 필요

### Refs
- Refs: #1
