### PR TITLE
feat/domain-reminder

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/reminder/entity/ReminderChannelAccount.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/reminder/entity/ReminderChannelAccount.java
@@ -1,0 +1,194 @@
+package org.qpeek.qpeek.domain.reminder.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Check;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.member.entity.Member;
+import org.qpeek.qpeek.domain.reminder.enums.ReminderChannelType;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+/**
+ * ReminderChannelAccount (리마인더 발송 채널 계정 엔티티)
+ * <p>
+ * <도메인 규칙/정책>
+ * 1. 한 Member 는 채널(ChannelType)별로 최대 1개의 계정만 가질 수 있음
+ * (DB 제약: UNIQUE(member_id, channel_type))
+ * 2. addressOrToken 은 null/빈 문자열 불가, 채널별 형식 검증 필수
+ * - EMAIL → 간단 이메일 패턴 검증
+ * - KAKAO → 토큰/식별자 길이 최소 10 이상
+ * - SLACK → `https://hooks.slack.com/services/` 로 시작해야 함
+ * - WEBPUSH → http/https URL 형식 필수
+ * 3. 채널 활성/비활성 플래그(channelEnabled)로 발송 가능 여부 제어
+ * 4. 외부 검증 완료 시 verifiedAt 을 기록, null 이면 미검증 상태
+ * 5. 발송 가능(canSend) 조건: channelEnabled = true 이면서 verifiedAt != null
+ * 6. Member 는 반드시 영속 상태여야 하며, 식별자(id)가 존재해야 함
+ * 7. 생성 후 채널/소유자 변경 불가
+ * <p>
+ * <설계 메모>
+ * - member:다대일 관계 (여러 채널 계정 보유 가능), member_id 는 FK (NOT NULL)
+ * - DB 제약: @Check(address_or_token <> ''), UNIQUE(member_id, channel_type)
+ * - 조회 성능: (member_id, channel_type, verified_at) 인덱스 구성
+ * - 주소/토큰 변경 시 updateAddressOrToken → 검증 상태 초기화(verifiedAt = null)
+ * - enable/disable 로 채널 활성화 상태 전환 가능
+ */
+
+@Entity
+@Getter
+@Check(constraints = "address_or_token <> ''")
+@Table(name = "reminder_channel_account",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_channel_member_type", columnNames = {"member_id", "channel_type"})
+        },
+        indexes = {
+                @Index(name = "idx_member_type_enabled", columnList = "member_id, channel_type, channel_enabled")
+        })
+@ToString(of = {"id", "channelType", "verifiedAt"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReminderChannelAccount extends BaseEntity {
+
+    private static final boolean DEFAULT_ENABLED = true;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "global_seq_gen")
+    @Column(name = "channel_account_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel_type", nullable = false, length = 20)
+    private ReminderChannelType channelType;
+
+    @JsonIgnore
+    @Column(name = "address_or_token", nullable = false, length = 512)
+    private String addressOrToken;
+
+    @JsonIgnore
+    @Column(name = "channel_enabled", nullable = false)
+    private boolean channelEnabled = DEFAULT_ENABLED;
+
+    @Column(name = "verified_at", columnDefinition = "timestamptz")
+    private OffsetDateTime verifiedAt;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+
+    private ReminderChannelAccount(ReminderChannelType channelType, String addressOrToken, boolean channelEnabled, OffsetDateTime verifiedAt, Member member) {
+        this.channelType = validNullOrBlank(channelType, "channel type");
+        this.addressOrToken = normalizeAndValid(channelType, addressOrToken);
+        this.channelEnabled = channelEnabled;
+        this.verifiedAt = verifiedAt; // 보통 null로 시작, 검증 성공 시 세팅
+        this.member = validMemberIsNull(member);
+    }
+
+
+    // 도메인 서비스 로직 ----------------------------------------------------------------
+
+
+    public static ReminderChannelAccount create(ReminderChannelType channelType, String addressOrToken, Member member) {
+        return new ReminderChannelAccount(channelType, addressOrToken, DEFAULT_ENABLED, null, member);
+    }
+
+    public static ReminderChannelAccount email(String email, Member member) {
+        return create(ReminderChannelType.EMAIL, email, member);
+    }
+
+    public static ReminderChannelAccount kakao(String kakaoUserIdOrToken, Member member) {
+        return create(ReminderChannelType.KAKAO, kakaoUserIdOrToken, member);
+    }
+
+    public static ReminderChannelAccount slack(String incomingWebhookUrl, Member member) {
+        return create(ReminderChannelType.SLACK, incomingWebhookUrl, member);
+    }
+
+    public static ReminderChannelAccount webPush(String endpoint, Member member) {
+        return create(ReminderChannelType.WEBPUSH, endpoint, member);
+    }
+
+
+    // 행위(도메인 메서드) ----------------------------------------------------------------
+
+
+    public void updateAddressOrToken(String newAddressOrToken) {
+        this.addressOrToken = normalizeAndValid(this.channelType, newAddressOrToken);
+        this.verifiedAt = null; // 주소/토큰이 바뀌면 검증 상태 초기화
+    }
+
+    public void enable() {
+        this.channelEnabled = true;
+    }
+
+    public void disable() {
+        this.channelEnabled = false;
+    }
+
+    public void setVerifiedAt(Clock clock) {
+        this.verifiedAt = OffsetDateTime.now(validNullOrBlank(clock, "clock"));
+    }
+
+    public boolean canSend() {
+        return this.channelEnabled && this.verifiedAt != null;
+    }
+
+
+    // 검증 로직 ----------------------------------------------------------------
+
+
+    private static Member validMemberIsNull(Member member) {
+        if (member == null || member.getId() == null) {
+            throw new IllegalArgumentException("member is null or transient");
+        }
+        return member;
+    }
+
+    private static <T> T validNullOrBlank(T value, String name) {
+        if (value == null) throw new IllegalArgumentException(name + " is null");
+        if (value instanceof CharSequence cs && cs.toString().isBlank())
+            throw new IllegalArgumentException(name + " is blank");
+        return value;
+    }
+
+
+    //TODO: SRP 위반 분리 필요
+    private static String normalizeAndValid(ReminderChannelType type, String raw) {
+        if (raw == null) throw new IllegalArgumentException("addressOrToken is null");
+        String v = raw.trim();
+        if (v.isEmpty()) throw new IllegalArgumentException("addressOrToken is blank");
+
+        switch (type) {
+            case EMAIL -> {
+                // 간단 이메일 검증 (RFC 완벽 X, 실무에선 추가 검증/도메인 제한 가능)
+                String email = v.toLowerCase();
+                if (!email.matches("^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"))
+                    throw new IllegalArgumentException("invalid email");
+                return email;
+            }
+            case KAKAO -> {
+                // 카카오 사용자 식별자/토큰(길이 최소 보장 정도)
+                if (v.length() < 10)
+                    throw new IllegalArgumentException("kakao token too short");
+                return v;
+            }
+            case SLACK -> {
+                // Incoming Webhook URL 형식 체크(대략)
+                if (!v.startsWith("https://hooks.slack.com/services/"))
+                    throw new IllegalArgumentException("invalid slack webhook url");
+                return v;
+            }
+            case WEBPUSH -> {
+                // 웹푸시 엔드포인트(대략 URL 형식 확인)
+                if (!v.startsWith("http://") && !v.startsWith("https://"))
+                    throw new IllegalArgumentException("invalid webPush endpoint");
+                return v;
+            }
+            default -> throw new IllegalStateException("unsupported channel type");
+        }
+    }
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/reminder/entity/ReminderSetting.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/reminder/entity/ReminderSetting.java
@@ -1,0 +1,158 @@
+package org.qpeek.qpeek.domain.reminder.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Check;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.member.entity.Member;
+
+
+/**
+ * ReminderSetting (임박/초과 판단에 사용하는 임계값 제공)
+ * <p>
+ * <도메인 정책>
+ * - imminentHours: 마감 임박 알림 시간 (0 ~ 168시간 = 최대 7일)
+ * - overdueIntervalHours: 마감 초과 후 반복 알림 주기 (0 = 최초 1회만, 양수 = n 시간마다 반복)
+ * - notifyDayBefore: 마감 전날 D-1 알림 여부 (default: true)
+ * - notifyOnDueDay: 마감 당일 알림 여부 (default: true)
+ * <p>
+ * <기본 설정값>
+ * - imminentHours = 3h
+ * - overdueIntervalHours = 24h
+ * - notifyDayBefore = true
+ * - notifyOnDueDay = true
+ */
+@Entity
+@Getter
+@Check(constraints =
+        "imminent_hours >= 0 AND imminent_hours <= 168 AND overdue_interval_hours >= 0")
+@Table(name = "reminder_setting")
+@ToString(of = {"id", "imminentHours", "overdueIntervalHours", "notifyDayBefore", "notifyOnDueDay"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+// TODO: @Cacheable(2차 캐시) 검토.
+public class ReminderSetting extends BaseEntity {
+
+    private static final int DEFAULT_IMMINENT_HOURS = 3;
+    private static final int DEFAULT_OVERDUE_INTERVAL_HRS = 24;
+    private static final boolean DEFAULT_NOTIFY_DAY_BEFORE = true;
+    private static final boolean DEFAULT_NOTIFY_ON_DUE = true;
+
+    @Id
+    @Column(name = "member_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(name = "imminent_hours", nullable = false)
+    private int imminentHours;
+
+    @Column(name = "overdue_interval_hours", nullable = false)
+    private int overdueIntervalHours;
+
+    @Column(name = "notify_day_before", nullable = false)
+    private boolean notifyDayBefore;
+
+    @Column(name = "notify_on_due_day", nullable = false)
+    private boolean notifyOnDueDay;
+
+    @JsonIgnore
+    @MapsId
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    private ReminderSetting(int imminentHours,
+                            int overdueIntervalHours,
+                            boolean notifyDayBefore,
+                            boolean notifyOnDueDay,
+                            Member member) {
+        validMemberIsNull(member);
+        validTimeValues(imminentHours, overdueIntervalHours);
+        this.imminentHours = imminentHours;
+        this.overdueIntervalHours = overdueIntervalHours;
+        this.notifyDayBefore = notifyDayBefore;
+        this.notifyOnDueDay = notifyOnDueDay;
+        this.member = member;
+    }
+
+
+    // 도메인 서비스 로직 ----------------------------------------------------------------
+
+
+    public static ReminderSetting create(int imminentHours,
+                                         boolean notifyDayBefore,
+                                         boolean notifyOnDueDay,
+                                         int overdueIntervalHours,
+                                         Member member) {
+        return new ReminderSetting(imminentHours, overdueIntervalHours, notifyDayBefore, notifyOnDueDay, member);
+    }
+
+    public static ReminderSetting createDefaultSetting(Member member) {
+        return new ReminderSetting(
+                DEFAULT_IMMINENT_HOURS,
+                DEFAULT_OVERDUE_INTERVAL_HRS,
+                DEFAULT_NOTIFY_DAY_BEFORE,
+                DEFAULT_NOTIFY_ON_DUE,
+                member
+        );
+    }
+
+
+    // 행위(도메인 메서드) ----------------------------------------------------------------
+
+
+    public void updateAll(int imminentHours,
+                          int overdueIntervalHours,
+                          boolean notifyDayBefore,
+                          boolean notifyOnDueDay) {
+        validTimeValues(imminentHours, overdueIntervalHours);
+        this.imminentHours = imminentHours;
+        this.overdueIntervalHours = overdueIntervalHours;
+        this.notifyDayBefore = notifyDayBefore;
+        this.notifyOnDueDay = notifyOnDueDay;
+    }
+
+    public void changeImminentHours(int value) {
+        validImminent(value);
+        this.imminentHours = value;
+    }
+
+    public void changeOverdueIntervalHours(int value) {
+        validOverdueInterval(value);
+        this.overdueIntervalHours = value;
+    }
+
+    public void enableDayBefore(boolean enabled) {
+        this.notifyDayBefore = enabled;
+    }
+
+    public void enableOnDueDay(boolean enabled) {
+        this.notifyOnDueDay = enabled;
+    }
+
+
+    // 검증 로직 ----------------------------------------------------------------
+
+
+    private static void validMemberIsNull(Member member) {
+        if (member == null || member.getId() == null) {
+            throw new IllegalArgumentException("member is null or transient");
+        }
+    }
+
+    private static void validTimeValues(int imminentHours, int overdueIntervalHours) {
+        validImminent(imminentHours);
+        validOverdueInterval(overdueIntervalHours);
+    }
+
+    private static void validImminent(int imminentHours) {
+        if (imminentHours < 0 || imminentHours > 168) {
+            throw new IllegalArgumentException("imminentHours must be between 0 and 168");
+        }
+    }
+
+    private static void validOverdueInterval(int overdueIntervalHours) {
+        if (overdueIntervalHours < 0) {
+            throw new IllegalArgumentException("overdueIntervalHours must be >= 0");
+        }
+    }
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/reminder/enums/ReminderChannelType.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/reminder/enums/ReminderChannelType.java
@@ -1,0 +1,5 @@
+package org.qpeek.qpeek.domain.reminder.enums;
+
+public enum ReminderChannelType {
+    EMAIL,KAKAO,WEBPUSH,SLACK
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/reminder/entity/ReminderChannelAccountTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/reminder/entity/ReminderChannelAccountTest.java
@@ -1,0 +1,340 @@
+package org.qpeek.qpeek.domain.reminder.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.member.entity.Member;
+import org.qpeek.qpeek.domain.reminder.enums.ReminderChannelType;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.*;
+
+class ReminderChannelAccountTest {
+
+    private static final Clock baseClock = Clock.fixed(Instant.parse("2025-08-08T00:00:00Z"), ZoneOffset.UTC);
+    private static final String EMAIL_ADDRESS = "user@example.com";
+    private static final String KAKAO_TOKEN = "KAKAOTOKEN"; // 길이 10+
+    private static final String SLACK_WEBHOOK = "https://hooks.slack.com/services/test";
+    private static final String WEBPUSH_ENDPOINT = "https://push.example.com/endpoint/test";
+
+    private Member memberWithId(Long id) {
+        Member member = Mockito.mock(Member.class);
+        Mockito.when(member.getId()).thenReturn(id);
+        return member;
+    }
+
+
+    // ------------------------------------------------------------------
+    // create()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create() success test")
+    void create_success() {
+        //given
+        Member member = memberWithId(1L);
+
+        //when
+        ReminderChannelAccount mailChannelAccount = ReminderChannelAccount.create(
+                ReminderChannelType.EMAIL, EMAIL_ADDRESS, member);
+
+        ReminderChannelAccount kakaoChannelAccount = ReminderChannelAccount.create(
+                ReminderChannelType.KAKAO, KAKAO_TOKEN, member);
+
+        ReminderChannelAccount slackChannelAccount = ReminderChannelAccount.create(
+                ReminderChannelType.SLACK, SLACK_WEBHOOK, member);
+
+        ReminderChannelAccount webPushChannelAccount = ReminderChannelAccount.create(
+                ReminderChannelType.WEBPUSH, WEBPUSH_ENDPOINT, member);
+
+        //then
+        basicTestByChannel(mailChannelAccount, ReminderChannelType.EMAIL, EMAIL_ADDRESS, member);
+        basicTestByChannel(kakaoChannelAccount, ReminderChannelType.KAKAO, KAKAO_TOKEN, member);
+        basicTestByChannel(slackChannelAccount, ReminderChannelType.SLACK, SLACK_WEBHOOK, member);
+        basicTestByChannel(webPushChannelAccount, ReminderChannelType.WEBPUSH, WEBPUSH_ENDPOINT, member);
+    }
+
+    @Test
+    @DisplayName("create() fail : ChannelType is null")
+    void create_fail_null_channel_type() {
+        // given
+        Member member = memberWithId(1L);
+
+        // then
+        assertThatThrownBy(() -> ReminderChannelAccount.create(null, "test", member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("channel type is null");
+    }
+
+    @Test
+    @DisplayName("create() fail : member is null or transient")
+    void create_fail_transient_member() {
+        // given
+        Member transientMember = memberWithId(null);
+
+        // then
+        assertThatThrownBy(() -> ReminderChannelAccount.create(ReminderChannelType.EMAIL, EMAIL_ADDRESS, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+
+        assertThatThrownBy(() -> ReminderChannelAccount.create(ReminderChannelType.EMAIL, EMAIL_ADDRESS, transientMember))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+    }
+
+    @Test
+    @DisplayName("create() fail : addressOrToken is null or blank")
+    void create_fail_null_or_blank_addressToken() {
+        // given
+        Member member = memberWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> ReminderChannelAccount.create(ReminderChannelType.EMAIL, null, member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("addressOrToken is null");
+
+        assertThatThrownBy(() -> ReminderChannelAccount.email("   ", member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("addressOrToken is blank");
+    }
+
+
+    // ------------------------------------------------------------------
+    // email(), kakao(), slack(), webPush()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("email() success test")
+    void email_success() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        ReminderChannelAccount account = ReminderChannelAccount.email(EMAIL_ADDRESS, member);
+
+        // then
+        basicTestByChannel(account, ReminderChannelType.EMAIL, EMAIL_ADDRESS, member);
+    }
+
+    @Test
+    @DisplayName("email() fail : invalid email pattern ")
+    void email_fail_invalid_email_pattern() {
+        // given
+        Member member = memberWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> ReminderChannelAccount.email("bad-email", member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid email");
+    }
+
+    @Test
+    @DisplayName("kakao() success test")
+    void kakao_success() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        ReminderChannelAccount account = ReminderChannelAccount.kakao(KAKAO_TOKEN, member);
+
+        // then
+        basicTestByChannel(account, ReminderChannelType.KAKAO, KAKAO_TOKEN, member);
+    }
+
+    @Test
+    @DisplayName("kakao() fail : invalid kakao token")
+    void kakao_fail_invalid_kakao_token() {
+        // given
+        Member member = memberWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> ReminderChannelAccount.kakao("short", member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("kakao token too short");
+    }
+
+    @Test
+    @DisplayName("slack() success test")
+    void slack_success() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        ReminderChannelAccount account = ReminderChannelAccount.slack(SLACK_WEBHOOK, member);
+
+        // then
+        basicTestByChannel(account, ReminderChannelType.SLACK, SLACK_WEBHOOK, member);
+    }
+
+    @Test
+    @DisplayName("slack() fail : invalid slack url pattern")
+    void slack_fail_slack_url() {
+        // given
+        Member member = memberWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> ReminderChannelAccount.slack("https://example.com/not-slack-hook", member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid slack webhook url");
+    }
+
+    @Test
+    @DisplayName("webPush() success test")
+    void webPush_success() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        ReminderChannelAccount account = ReminderChannelAccount.webPush(WEBPUSH_ENDPOINT, member);
+
+        // then
+        basicTestByChannel(account, ReminderChannelType.WEBPUSH, WEBPUSH_ENDPOINT, member);
+    }
+
+    @Test
+    @DisplayName("webPush() fail : invalid webPush url")
+    void web_push_fail_invalid_web_push_url() {
+        // given
+        Member member = memberWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> ReminderChannelAccount.webPush("XXX://example.com", member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("invalid webPush endpoint");
+    }
+
+    private static void basicTestByChannel(ReminderChannelAccount account, ReminderChannelType type, String addressOrToken, Member member) {
+        assertThat(account.getChannelType()).isEqualTo(type);
+        assertThat(account.getAddressOrToken()).isEqualTo(addressOrToken);
+        assertThat(account.isChannelEnabled()).isTrue();
+        assertThat(account.getVerifiedAt()).isNull();
+        assertThat(account.getMember()).isEqualTo(member);
+        assertThat(account.canSend()).isFalse(); // verifiedAt == null 이므로 false
+    }
+
+
+    // ------------------------------------------------------------------
+    //  enable(), disable()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("enable() disable() success test")
+    void enable_disable() {
+        //given
+        Member member = memberWithId(1L);
+        ReminderChannelAccount account = ReminderChannelAccount.email(EMAIL_ADDRESS, member);
+        assertThat(account.isChannelEnabled()).isTrue();
+
+        account.disable(); //when
+        assertThat(account.isChannelEnabled()).isFalse(); //then
+
+        account.enable(); //when
+        assertThat(account.isChannelEnabled()).isTrue(); //then
+    }
+
+
+    // ------------------------------------------------------------------
+    //  setVerifiedAt(), canSend()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("setVerifiedAt() success test")
+    void setVerifiedAt_success() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderChannelAccount account = ReminderChannelAccount.email(EMAIL_ADDRESS, member);
+
+        // when
+        account.setVerifiedAt(baseClock);
+
+        // then
+        assertThat(account.getVerifiedAt()).isEqualTo(
+                OffsetDateTime.ofInstant(Instant.parse("2025-08-08T00:00:00Z"), ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("setVerifiedAt() fail test : clock is null")
+    void setVerifiedAt_fail_null_clock() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderChannelAccount account = ReminderChannelAccount.email(EMAIL_ADDRESS, member);
+
+        // then
+        assertThatThrownBy(() -> account.setVerifiedAt(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("clock is null");
+    }
+
+    @Test
+    @DisplayName("canSend() test : ( enabled=true && verifiedAt!=null ) is true")
+    void canSend_test() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderChannelAccount account = ReminderChannelAccount.email(EMAIL_ADDRESS, member);
+
+        assertThat(account.isChannelEnabled()).isTrue();
+        assertThat(account.getVerifiedAt()).isNull();
+        assertThat(account.canSend()).isFalse();
+
+
+        account.setVerifiedAt(baseClock); // when
+        assertThat(account.canSend()).isTrue(); // then
+
+        account.disable(); // when
+        assertThat(account.isChannelEnabled()).isFalse(); // then
+        assertThat(account.canSend()).isFalse(); // then
+
+        account.enable(); // when
+        assertThat(account.isChannelEnabled()).isTrue(); // then
+        assertThat(account.canSend()).isTrue(); //then
+    }
+
+
+    // ------------------------------------------------------------------
+    //  updateAddressOrToken()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateAddressOrToken() success test")
+    void updateAddressOrToken_success() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderChannelAccount account = ReminderChannelAccount.email(EMAIL_ADDRESS, member);
+        account.setVerifiedAt(baseClock);
+        assertThat(account.getVerifiedAt()).isNotNull();
+
+        // when
+        account.updateAddressOrToken("NewAddress@example.com");
+
+        // then
+        assertThat(account.getAddressOrToken()).isEqualTo("newaddress@example.com"); // lowercased
+        assertThat(account.getVerifiedAt()).isNull(); // 주소 갱신 시 검증상태 초기화(verifiedAt=null), 형식 재검증
+        assertThat(account.getChannelType()).isEqualTo(ReminderChannelType.EMAIL); // 불변
+        assertThat(account.getMember()).isEqualTo(member);
+        assertThat(account.canSend()).isFalse();
+    }
+
+    @Test
+    @DisplayName("updateAddressOrToken() fail")
+    void updateAddressOrToken_fail_rollback() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderChannelAccount account = ReminderChannelAccount.email(EMAIL_ADDRESS, member);
+        account.setVerifiedAt(baseClock);
+
+        OffsetDateTime before = account.getVerifiedAt();
+
+        //then
+        assertThatThrownBy(() -> account.updateAddressOrToken("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("addressOrToken is blank");
+
+
+        assertThat(account.getVerifiedAt()).isEqualTo(before); // 검증 실패 시 상태 롤백(verifiedAt 유지)
+        assertThat(account.getAddressOrToken()).isEqualTo(EMAIL_ADDRESS);
+    }
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/reminder/entity/ReminderSettingTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/reminder/entity/ReminderSettingTest.java
@@ -1,0 +1,219 @@
+package org.qpeek.qpeek.domain.reminder.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.member.entity.Member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ReminderSettingTest {
+
+    private Member memberWithId(Long id) {
+        Member mock = Mockito.mock(Member.class);
+        Mockito.when(mock.getId()).thenReturn(id);
+        return mock;
+    }
+
+    @Test
+    @DisplayName("create() success test")
+    void create_success() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        ReminderSetting setting = ReminderSetting
+                .create(3, true, true, 24, member);
+
+        // then
+        assertThat(setting.getImminentHours()).isEqualTo(3);
+        assertThat(setting.getOverdueIntervalHours()).isEqualTo(24);
+        assertThat(setting.isNotifyDayBefore()).isTrue();
+        assertThat(setting.isNotifyOnDueDay()).isTrue();
+        assertThat(setting.getMember()).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("createDefaultSetting() success test")
+    void createDefault_success() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        // then
+        assertThat(setting.getImminentHours()).isEqualTo(3);
+        assertThat(setting.getOverdueIntervalHours()).isEqualTo(24);
+        assertThat(setting.isNotifyDayBefore()).isTrue();
+        assertThat(setting.isNotifyOnDueDay()).isTrue();
+        assertThat(setting.getMember()).isEqualTo(member);
+    }
+
+    @Test
+    @DisplayName("create() fail test : member is transient")
+    void create_fail_transient_member() {
+        // given
+        Member transientMember = memberWithId(null);
+
+        // then
+        assertThatThrownBy(() -> ReminderSetting.create(3, true, true, 24, transientMember))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+    }
+
+    @Test
+    @DisplayName("create() fail test : member is null")
+    void create_fail_null_member() {
+        // then
+        assertThatThrownBy(() -> ReminderSetting.create(3, true, true, 24, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+    }
+
+    @Test
+    @DisplayName("create() fail test : invalid imminentHours")
+    void create_fail_invalid_imminent() {
+        // given
+        Member member = memberWithId(1L);
+
+        // then
+        assertThatThrownBy(() -> ReminderSetting.create(-1, true, true, 24, member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("imminentHours must be between 0 and 168");
+
+        assertThatThrownBy(() -> ReminderSetting.create(169, true, true, 24, member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("imminentHours must be between 0 and 168");
+    }
+
+    @Test
+    @DisplayName("create() fail test : invalid overdueIntervalHours")
+    void create_fail_invalid_overdueInterval() {
+        // given
+        Member member = memberWithId(1L);
+
+        // then
+        assertThatThrownBy(() -> ReminderSetting.create(3, true, true, -1, member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("overdueIntervalHours must be >= 0");
+    }
+
+    @Test
+    @DisplayName("updateAll() success test")
+    void updateAll_success() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        // when
+        setting.updateAll(10, 12, false, false);
+
+        // then
+        assertThat(setting.getImminentHours()).isEqualTo(10);
+        assertThat(setting.getOverdueIntervalHours()).isEqualTo(12);
+        assertThat(setting.isNotifyDayBefore()).isFalse();
+        assertThat(setting.isNotifyOnDueDay()).isFalse();
+    }
+
+    @Test
+    @DisplayName("updateAll() fail test : invalid arguments")
+    void updateAll_fail_invalid_arguments() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        // then
+        assertThatThrownBy(() -> setting.updateAll(200, 12, true, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("imminentHours must be between 0 and 168");
+
+        assertThatThrownBy(() -> setting.updateAll(10, -1, true, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("overdueIntervalHours must be >= 0");
+    }
+
+
+    @Test
+    @DisplayName("changeImminentHours() success test")
+    void changeImminent_success() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        setting.changeImminentHours(0); // when
+        assertThat(setting.getImminentHours()).isEqualTo(0); // then
+
+        setting.changeImminentHours(168); // when
+        assertThat(setting.getImminentHours()).isEqualTo(168); // then
+    }
+
+    @Test
+    @DisplayName("changeImminentHours() fail test : invalid imminentHours")
+    void changeImminent_fail_invalid_imminentHours() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        // then
+        assertThatThrownBy(() -> setting.changeImminentHours(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("imminentHours must be between 0 and 168");
+
+        assertThatThrownBy(() -> setting.changeImminentHours(169))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("imminentHours must be between 0 and 168");
+    }
+
+    @Test
+    @DisplayName("changeOverdueIntervalHours() success test")
+    void changeOverdueInterval_success() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        setting.changeOverdueIntervalHours(0); // when
+        assertThat(setting.getOverdueIntervalHours()).isEqualTo(0); // then
+
+        setting.changeOverdueIntervalHours(5); // when
+        assertThat(setting.getOverdueIntervalHours()).isEqualTo(5); // then
+    }
+
+    @Test
+    @DisplayName("changeOverdueIntervalHours() fail test : negative OverdueIntervalHours ")
+    void changeOverdueInterval_fail_negative_OverdueIntervalHours() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        // then
+        assertThatThrownBy(() -> setting.changeOverdueIntervalHours(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("overdueIntervalHours must be >= 0");
+    }
+
+    @Test
+    @DisplayName("enableDayBefore(), enableOnDueDay() success test")
+    void enable_flags_success() {
+        // given
+        Member member = memberWithId(1L);
+        ReminderSetting setting = ReminderSetting.createDefaultSetting(member);
+
+        // when
+        setting.enableDayBefore(false);
+        setting.enableOnDueDay(false);
+
+        // then
+        assertThat(setting.isNotifyDayBefore()).isFalse();
+        assertThat(setting.isNotifyOnDueDay()).isFalse();
+
+        // when
+        setting.enableDayBefore(true);
+        setting.enableOnDueDay(true);
+
+        // then
+        assertThat(setting.isNotifyDayBefore()).isTrue();
+        assertThat(setting.isNotifyOnDueDay()).isTrue();
+    }
+}


### PR DESCRIPTION
### What
- ReminderChannelType enums 추가

- ReminderSetting Entity 추가
- ReminderSetting Entity Test 추가

- ReminderChannelAccount Entity 추가
- ReminderChannelAccount Entity Test 추가


### Why
- Reminder 알림에 필요한 데이터 저장 및 알림 전송 로깅 용도


### Changes
- `domain-reminder-entity` : 
  - ReminderChannelAccount ,
  - ReminderChannelAccountTest,
  - ReminderSetting,
  - ReminderSettingTest
  
- `domain-reminder-enums`  : ReminderChannelType 


### Note
- ISSUE 추가
  - ReminderChannelAccount Entity 의 `normalizeAndValid()` 함수 SRP 위반으로 분리 필요

- feat(domain-reminder) : ReminderChannelAccount Entity 추가
- ReminderChannelAccount.java
  - Line = 159:25

### Refs
- Refs: #7



