### PR TITLE
feat/domain-database

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/database/entity/Database.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/database/entity/Database.java
@@ -1,0 +1,132 @@
+package org.qpeek.qpeek.domain.database.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Check;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.member.entity.Member;
+import org.qpeek.qpeek.domain.queue.entity.TaskQueue;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Database (저장소)
+ * <p>
+ * <도메인 규칙/정책>
+ * - owner(member): 저장소 소유자. 생성 후 변경 불가(updatable = false).
+ * - name: 회원 단위 유니크((member_id, name)). 원문 보존(공백 포함)하며 전부 공백만은 금지, 길이 ≤ 100.
+ * - description: 선택(Optional). 원문 보존, 전부 공백만이면 null로 정규화, 길이 ≤ 500.
+ * - deletedAt: 소프트 삭제 시각. OffsetDateTime(timestamptz). null이면 활성 상태.
+ * - 권한: rename / deleteByOwner 는 소유자만 가능(ensureOwner로 검증).
+ * <p>
+ * <설계 메모>
+ * - 유니크 제약: (member_id, name)으로 회원별 이름 중복 방지.
+ * - 인덱스: member_id, deleted_at(활성 목록/정리 배치 성능 목적). 운영 시 WHERE deleted_at IS NULL 부분 인덱스 고려 가능.
+ */
+@Entity
+@Getter
+@Table(name = "databases",
+        uniqueConstraints = @UniqueConstraint(name = "uk_databases_member_name", columnNames = {"member_id", "name"}),
+        indexes = {
+                @Index(name = "idx_databases_member", columnList = "member_id"),
+                @Index(name = "idx_databases_deleted_at", columnList = "deleted_at")
+        })
+@Check(constraints = "name <> ''")
+@ToString(of = {"id", "name", "description", "deletedAt"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Database extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "global_seq_gen")
+    @Column(name = "database_id")
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "deleted_at", columnDefinition = "timestamptz")
+    private OffsetDateTime deletedAt;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "database", fetch = FetchType.LAZY)
+    private List<TaskQueue> queues = new ArrayList<>();
+
+    private Database(String name, String description, Member member) {
+        this.name = normalizeName(name);
+        this.description = normalizeDesc(description); // 공백만이면 null, 아니면 원문 보존
+        this.deletedAt = null;
+        this.member = validMemberIsNull(member);
+    }
+
+
+    // 도메인 서비스 로직 ----------------------------------------------------------------
+
+
+    public static Database create(String name, String description, Member member) {
+        return new Database(name, description, member);
+    }
+
+
+    // 행위(도메인 메서드) ----------------------------------------------------------------
+
+
+    public void rename(String newName, String newDescription, Member actor) {
+        ensureOwner(actor);
+        this.name = normalizeName(newName);
+        this.description = normalizeDesc(newDescription);
+    }
+
+    public void deleteByOwner(Clock clock, Member actor) {
+        ensureOwner(actor);
+        if (clock == null) throw new IllegalArgumentException("clock is null");
+        if (this.deletedAt == null) {
+            this.deletedAt = OffsetDateTime.now(clock);
+        }
+    }
+
+
+    // 검증 로직 ----------------------------------------------------------------
+
+
+    private static Member validMemberIsNull(Member member) {
+        if (member == null || member.getId() == null)
+            throw new IllegalArgumentException("member is null or transient");
+        return member;
+    }
+
+    private void ensureOwner(Member actor) {
+        if (actor == null || actor.getId() == null)
+            throw new IllegalArgumentException("actor is null or transient");
+        if (!Objects.equals(this.member.getId(), actor.getId()))
+            throw new SecurityException("actor is not this database owner");
+    }
+
+    private static String normalizeName(String raw) {
+        if (raw == null) throw new IllegalArgumentException("name is null");
+        if (raw.isBlank()) throw new IllegalArgumentException("name is blank");
+        if (raw.length() > 100) throw new IllegalArgumentException("name length > 100");
+        return raw;
+    }
+
+    private static String normalizeDesc(String raw) {
+        if (raw == null) return null;
+        if (raw.isBlank()) return null;
+        if (raw.length() > 500) throw new IllegalArgumentException("description length > 500");
+        return raw;
+    }
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/database/entity/DatabaseTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/database/entity/DatabaseTest.java
@@ -1,0 +1,247 @@
+package org.qpeek.qpeek.domain.database.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.member.entity.Member;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+class DatabaseTest {
+
+    private final Clock baseClock = Clock.fixed(Instant.parse("2025-08-08T00:00:00Z"), ZoneOffset.UTC);
+
+    private Member memberWithId(long id) {
+        Member mock = Mockito.mock(Member.class);
+        Mockito.when(mock.getId()).thenReturn(id);
+        return mock;
+    }
+
+    // ------------------------------------------------------------------
+    // create()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create() success test")
+    void create_success() {
+        //given
+        String dbName = "Project DB";
+        String dbDesc = "Project 개인 DB";
+        Member member = memberWithId(1L);
+
+        //when
+        Database database = Database.create(dbName, dbDesc, member);
+
+        //then
+        assertThat(database.getMember().getId()).isEqualTo(member.getId());
+        assertThat(database.getName()).isEqualTo(dbName);
+        assertThat(database.getDescription()).isEqualTo(dbDesc);
+        assertThat(database.getDeletedAt()).isNull();
+        assertThat(database.getQueues()).isNotNull().isEmpty();
+    }
+
+    @Test
+    @DisplayName("create() fail test : transient member")
+    void create_fail_transient_member() {
+        //given
+        String dbName = "Project DB";
+        String dbDesc = "Project 개인 DB";
+
+        //when
+        Member transientMember = Mockito.mock(Member.class);
+        Mockito.when(transientMember.getId()).thenReturn(null);
+
+        //then
+        assertThatThrownBy(() -> Database.create(dbName, dbDesc, transientMember))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+    }
+
+    @Test
+    @DisplayName("create() fail test : invalid name")
+    void create_fail_invalid_name() {
+        //given
+        String dbName = "a";
+        String dbDesc = "a";
+        Member member = memberWithId(1L);
+
+
+        //then
+        assertThatThrownBy(() -> Database.create(
+                dbName.repeat(101),
+                dbDesc,
+                member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("name length > 100");
+
+        assertThatThrownBy(() -> Database.create(
+                " ",
+                dbDesc,
+                member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("name is blank");
+
+        assertThatThrownBy(() -> Database.create(
+                null,
+                dbDesc,
+                member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("name is null");
+    }
+
+    @Test
+    @DisplayName("create() fail test : invalid description")
+    void create_fail_invalid_desc() {
+        //given
+        String dbName = "a";
+        String dbDesc = "a";
+        Member member = memberWithId(1L);
+
+
+        //then
+        assertThatThrownBy(() -> Database.create(
+                dbName,
+                dbDesc.repeat(501),
+                member))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("description length > 500");
+
+
+        Database blankDescDatabase = Database.create(dbName, "   ", member);
+        assertThat(blankDescDatabase.getDescription()).isNull();
+
+        Database nullDescDatabase = Database.create(dbName, null, member);
+        assertThat(nullDescDatabase.getDescription()).isNull();
+    }
+
+
+    // ------------------------------------------------------------------
+    // rename()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("rename() success test")
+    void rename_success() {
+        //given
+        String dbName = "Project DB";
+        String dbDesc = "Project 개인 DB";
+        Member member = memberWithId(1L);
+
+        //when
+        Database database = Database.create(dbName, dbDesc, member);
+
+        String newName = "Project 팀 DB";
+        String newDesc = "Project 팀 협업 DB";
+        database.rename(newName, newDesc, member);
+
+        //then
+        assertThat(database.getName()).isEqualTo(newName);
+        assertThat(database.getDescription()).isEqualTo(newDesc);
+    }
+
+
+    @Test
+    @DisplayName("rename() fail test : actor is not owner")
+    void rename_fail_not_owner() {
+        //given
+        String dbName = "Project DB";
+        String dbDesc = "Project 개인 DB";
+        Member owner = memberWithId(1L);
+        Member notOwner = memberWithId(2L);
+
+        //when
+        Database database = Database.create(dbName, dbDesc, owner);
+
+        String newName = "Project 팀 DB";
+        String newDesc = "Project 팀 협업 DB";
+
+        //then
+        assertThatThrownBy(() -> database.rename(newName, newDesc, notOwner))
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("actor is not this database owner");
+    }
+
+    @Test
+    @DisplayName("rename() fail test : actor is null or transient")
+    void rename_fail_actor_transient() {
+        //given
+        String dbName = "Project DB";
+        String dbDesc = "Project 개인 DB";
+        Member owner = memberWithId(1L);
+
+        //when
+        Database database = Database.create(dbName, dbDesc, owner);
+
+        String newName = "Project 팀 DB";
+        String newDesc = "Project 팀 협업 DB";
+        Member transientMember = Mockito.mock(Member.class);
+        Mockito.when(transientMember.getId()).thenReturn(null);
+
+        //then
+        assertThatThrownBy(() -> database.rename(newName, newDesc, transientMember))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("actor is null or transient");
+
+        assertThatThrownBy(() -> database.rename(newName, newDesc, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("actor is null or transient");
+    }
+
+
+    // ------------------------------------------------------------------
+    // deleteByOwner()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deleteByOwner() success test")
+    void deleteByOwner_success() {
+        //given
+        String dbName = "Project DB";
+        String dbDesc = "Project 개인 DB";
+        Member owner = memberWithId(1L);
+
+        Clock t0 = baseClock;
+        Clock t1 = Clock.offset(t0, Duration.ofHours(1));
+
+        //when
+        Database database = Database.create(dbName, dbDesc, owner);
+        database.deleteByOwner(t0, owner);
+
+        //then
+        assertThat(database.getDeletedAt()).isEqualTo(OffsetDateTime.now(t0));
+
+        database.deleteByOwner(t1, owner);
+        assertThat(database.getDeletedAt()).isEqualTo(OffsetDateTime.now(t0));
+    }
+
+    @Test
+    @DisplayName("deleteByOwner() fail test : actor is not owner")
+    void deleteByOwner_fail_not_owner() {
+        //given
+        String dbName = "Project DB";
+        String dbDesc = "Project 개인 DB";
+        Member owner = memberWithId(1L);
+        Member notOwner = memberWithId(2L);
+
+        //when
+        Member transientMember = Mockito.mock(Member.class);
+        Mockito.when(transientMember.getId()).thenReturn(null);
+
+        Database database = Database.create(dbName, dbDesc, owner);
+
+        //then
+        assertThatThrownBy(() -> database.deleteByOwner(baseClock, notOwner))
+                .isInstanceOf(SecurityException.class)
+                .hasMessage("actor is not this database owner");
+
+        assertThatThrownBy(() -> database.deleteByOwner(baseClock, transientMember))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("actor is null or transient");
+
+        assertThatThrownBy(() -> database.deleteByOwner(baseClock, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("actor is null or transient");
+    }
+}


### PR DESCRIPTION
### What
- Database Entity 추가
- Database Entity Test 추가


### Why
- 여러 작업 Queue를 구분하는 Database(저장소) 용도 


### Changes
- `domain-database` :
    - Database
    - DatabaseTest,


### Note
(없음)

### Refs
(없음)



