### PR TITLE
feat/domain-task-queue

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/queue/entity/TaskQueue.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/queue/entity/TaskQueue.java
@@ -1,0 +1,120 @@
+package org.qpeek.qpeek.domain.queue.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.database.entity.Database;
+import org.qpeek.qpeek.domain.task.entity.Task;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * Queue (작업 큐)
+ * <p>
+ * <도메인 규칙/정책>
+ * - database: 소속 저장소(필수). 생성 후 변경 불가(updatable=false).
+ * - name: 원문 보존(공백 포함). 전부 공백만은 금지, 길이 ≤ 100.
+ * - description: 선택(Optional). 원문 보존, 전부 공백만이면 null, 길이 ≤ 500.
+ * - maxTasks: 기본 50. addTask 시 개수 제한 검사.
+ * - version: 재정렬 낙관적 잠금 버전(@Version). reorder에서 동시성 제어에 사용.
+ * <p>
+ * <설계 메모>
+ * - UNIQUE (database_id, name): 같은 DB 안에서 큐 이름 중복 금지(다른 DB끼리는 허용).
+ * - INDEX (database_id): "특정 DB의 큐 목록" 조회/카운트 최적화.
+ * - INDEX (database_id, created_at): DB별 목록을 생성일로 정렬/페이징할 때 커버.
+ * - Queue(1) — Task(*)
+ * - Queue(1) — RecurringRule(0..*)
+ */
+@Entity
+@Getter
+@Table(name = "queues",
+        uniqueConstraints = @UniqueConstraint(name = "uk_queues_db_name", columnNames = {"database_id", "name"}),
+        indexes = {
+                @Index(name = "idx_queues_db", columnList = "database_id"),
+                @Index(name = "idx_queues_db_created_at", columnList = "database_id, created_at")
+        })
+@ToString(of = {"id", "name", "description", "maxTasks"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TaskQueue extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "global_seq_gen")
+    @Column(name = "queue_id")
+    private Long id;
+
+    @Version
+    @Column(name = "version")
+    private Long version;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "max_tasks", nullable = false)
+    private int maxTasks = 50;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "database_id", nullable = false, updatable = false)
+    private Database database;
+
+    @JsonIgnore
+    @OneToMany(mappedBy = "queue", fetch = FetchType.LAZY)
+    private List<Task> tasks = new ArrayList<>();
+
+    private TaskQueue(String name, String description, Integer maxTasks, Database database) {
+        this.name = normalizeName(name);
+        this.description = normalizeDesc(description);
+        if (maxTasks != null) this.maxTasks = validMaxTasks(maxTasks);
+        this.database = validDatabaseIsNull(database);
+    }
+
+
+    // 도메인 서비스 로직 ----------------------------------------------------------------
+
+
+    public static TaskQueue create(String name, String description, Database database) {
+        return new TaskQueue(name, description, null, database);
+    }
+
+    public static TaskQueue createWithLimit(String name, String description, int maxTasks, Database database) {
+        return new TaskQueue(name, description, maxTasks, database);
+    }
+
+
+    // 검증 로직 ----------------------------------------------------------------
+
+
+    private static Database validDatabaseIsNull(Database db) {
+        if (db == null || db.getId() == null)
+            throw new IllegalArgumentException("database is null or transient");
+        return db;
+    }
+
+    private static String normalizeName(String raw) {
+        if (raw == null) throw new IllegalArgumentException("name is null");
+        if (raw.isBlank()) throw new IllegalArgumentException("name is blank");
+        if (raw.length() > 100) throw new IllegalArgumentException("name length > 100");
+        return raw; // 원문 보존 (trim 하지 않음)
+    }
+
+    private static String normalizeDesc(String raw) {
+        if (raw == null) return null;
+        if (raw.isBlank()) return null; // 전부 공백이면 null 정규화
+        if (raw.length() > 500) throw new IllegalArgumentException("description length > 500");
+        return raw; // 원문 보존
+    }
+
+    private static int validMaxTasks(int n) {
+        if (n <= 0) throw new IllegalArgumentException("maxTasks must be > 0");
+        return n;
+    }
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/queue/entity/TaskQueueTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/queue/entity/TaskQueueTest.java
@@ -1,0 +1,157 @@
+package org.qpeek.qpeek.domain.queue.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.database.entity.Database;
+
+import static org.assertj.core.api.Assertions.*;
+
+class TaskQueueTest {
+    private Database databaseWithId(Long id) {
+        Database mock = Mockito.mock(Database.class);
+        Mockito.when(mock.getId()).thenReturn(id);
+        return mock;
+    }
+
+    // ------------------------------------------------------------------
+    // create()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create() success test")
+    void create_success() {
+        //given
+        Database database = databaseWithId(1L);
+        String queueName = " Queue / 2025 ";
+        String description = "   ";
+
+        //when
+        TaskQueue taskQueue = TaskQueue.create(queueName, description, database);
+
+        //then
+        assertThat(taskQueue.getId()).isNull();
+        assertThat(taskQueue.getVersion()).isNull();
+        assertThat(taskQueue.getName()).isEqualTo(queueName); // name 은 trim() 하지 않고 원문 보존
+        assertThat(taskQueue.getDescription()).isNull(); // desc 는 blank -> null 처리
+        assertThat(taskQueue.getMaxTasks()).isEqualTo(50); // default queue size 50
+        assertThat(taskQueue.getDatabase()).isEqualTo(database);
+        assertThat(taskQueue.getTasks()).isNotNull();
+        assertThat(taskQueue.getTasks()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("create() fail test : name is null")
+    void create_fail_name_null() {
+        //given
+        Database database = databaseWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> TaskQueue.create(null, "description", database))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("name is null");
+    }
+
+    @Test
+    @DisplayName("create() fail test : name is blank")
+    void create_fail_name_blank() {
+        //given
+        Database database = databaseWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> TaskQueue.create("   ", "description", database))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("name is blank");
+    }
+
+    @Test
+    @DisplayName("create() fail test : name.length > 100")
+    void create_fail_invalid_name_length() {
+        //given
+        Database database = databaseWithId(1L);
+        String queueName = "a".repeat(101);
+
+        //then
+        assertThatThrownBy(() -> TaskQueue.create(queueName, "description", database))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("name length > 100");
+    }
+
+    @Test
+    @DisplayName("description normalization test")
+    void description_normalization() {
+        //given
+        Database database = databaseWithId(1L);
+
+        // null → null
+        TaskQueue queue1 = TaskQueue.create("Queue Name", null, database); // when
+        assertThat(queue1.getDescription()).isNull(); // then
+
+        // 공백-only → null
+        TaskQueue queue2 = TaskQueue.create("Queue Name", "   \t  ", database); // when
+        assertThat(queue2.getDescription()).isNull(); // then
+
+        // 500자 이하 허용
+        String descriptionUnder500 = "a".repeat(500);
+        TaskQueue queue3 = TaskQueue.create("Queue Name", descriptionUnder500, database); // when
+        assertThat(queue3.getDescription()).isEqualTo(descriptionUnder500); // then
+
+        // 500자 초과 예외
+        String descriptionOver500 = "a".repeat(501);
+        assertThatThrownBy(() -> TaskQueue.create("Queue Name", descriptionOver500, database))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("description length > 500");
+    }
+
+    @Test
+    @DisplayName("create() fail test : database is null or transient")
+    void create_fail_database_null_or_transient() {
+        //given
+        Database transientDb = databaseWithId(null);
+
+        //then
+        assertThatThrownBy(() -> TaskQueue.create("Queue Name", "description", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("database is null or transient");
+
+        assertThatThrownBy(() -> TaskQueue.create("Queue Name", "description", transientDb))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("database is null or transient");
+    }
+
+
+    // ------------------------------------------------------------------
+    // createWithLimit()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createWithLimit() success test")
+    void createWithLimit_success() {
+        //given
+        Database database = databaseWithId(1L);
+        String queueName = " Queue / 2025 ";
+        String description = "   ";
+
+        //when
+        TaskQueue taskQueue = TaskQueue.createWithLimit(queueName, description, 200, database);
+
+        //then
+        assertThat(taskQueue.getName()).isEqualTo(queueName);
+        assertThat(taskQueue.getDescription()).isNull();
+        assertThat(taskQueue.getMaxTasks()).isEqualTo(200);
+        assertThat(taskQueue.getDatabase()).isEqualTo(database);
+    }
+
+    @Test
+    @DisplayName("createWithLimit() fail test : maxTasks <= 0")
+    void createWithLimit_fail_invalid_max_tasks() {
+        Database database = databaseWithId(1L);
+        assertThatThrownBy(() -> TaskQueue.createWithLimit("Queue Name", "description", 0, database))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxTasks must be > 0");
+
+        assertThatThrownBy(() -> TaskQueue.createWithLimit("Queue Name", "description", -1, database))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("maxTasks must be > 0");
+    }
+}


### PR DESCRIPTION
### What
- TaskQueue Entity 추가
- TaskQueue Entity Test 추가


### Why
- Task(작업)을 보관 및 관리하는 용도


### Changes
- `domain-queue` :
    - TaskQueue
    - TaskQueueTest,


### Note
(없음)

### Refs
(없음)
