### PR TITLE
feat/domain-task

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/task/entity/Task.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/task/entity/Task.java
@@ -1,0 +1,227 @@
+package org.qpeek.qpeek.domain.task.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Check;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.queue.entity.TaskQueue;
+import org.qpeek.qpeek.domain.task.enums.DueStatus;
+import org.qpeek.qpeek.domain.task.enums.TaskImportance;
+import org.qpeek.qpeek.domain.task.enums.TaskStatus;
+import org.qpeek.qpeek.domain.task.enums.TaskTemplateType;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+/**
+ * Database (저장소)
+ * <p>
+ * <도메인 규칙/정책>
+ * - owner(member): 저장소 소유자. 생성 후 변경 불가(updatable = false).
+ * - name: 회원 단위 유니크((member_id, name)). 원문 보존(공백 포함), 전부 공백만은 금지, 길이 ≤ 100.
+ * - description: 선택(Optional). 원문 보존, 전부 공백만이면 null로 정규화, 길이 ≤ 500.
+ * - deletedAt: 소프트 삭제 시각. OffsetDateTime(timestamptz). null이면 활성 상태.
+ * - createdAt/updatedAt: BaseEntity 에서 감사(Auditing)로 관리(UTC 저장 권장).
+ * - 권한: rename / deleteByOwner 는 소유자만 가능(ensureOwner로 검증).
+ * <p>
+ * <설계 메모>
+ * - 유니크 제약: (member_id, name)으로 회원별 이름 중복 방지.
+ * - 소프트 삭제 후 이름 재사용 필요 시 부분 유니크 인덱스 고려: WHERE deleted_at IS NULL.
+ * - 인덱스: member_id(목록/카운트), deleted_at(정리 배치).
+ * - 공백 정책: trim 미사용, isBlank()로 공백-only만 차단하여 원문 보존.
+ * - 삭제 전략: 소프트 삭제 → 배치 퍼지에서 하위(queues→tasks…) 명시적 삭제.
+ */
+@Entity
+@Getter
+@Table(name = "tasks", indexes = {
+        @Index(name = "idx_tasks_queue", columnList = "queue_id"),
+        @Index(name = "idx_tasks_queue_status_priority", columnList = "queue_id, status, priority_index"),
+        @Index(name = "idx_tasks_queue_due", columnList = "queue_id, due_at")
+})
+@Check(constraints = "progress BETWEEN 0 AND 100 AND btrim(title) <> ''")
+@ToString(of = {"id", "title", "status", "progress", "priorityIndex"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Task extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "global_seq_gen")
+    @Column(name = "task_id")
+    private Long id;
+
+    @Column(name = "title", nullable = false)
+    private String title;
+
+    @Lob
+    @Column(name = "content", columnDefinition = "text")
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "template_type", length = 20)
+    private TaskTemplateType templateType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "importance")
+    private TaskImportance importance;
+
+    @Column(name = "due_at", columnDefinition = "timestamptz")
+    private OffsetDateTime dueAt;
+
+    @Column(name = "completed_at", columnDefinition = "timestamptz")
+    private OffsetDateTime completedAt;
+
+    @Column(name = "trashed_at", columnDefinition = "timestamptz")
+    private OffsetDateTime trashedAt;
+
+    @Column(name = "progress", nullable = false)
+    private int progress;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private TaskStatus status;
+
+    @Column(name = "priority_index")
+    private Long priorityIndex;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "queue_id", nullable = false, updatable = false)
+    private TaskQueue queue;
+
+    private Task(String title, TaskQueue queue) {
+        this.title = normalizeTitle(title);
+        this.content = null;
+        this.templateType = null;
+        this.importance = null;
+        this.progress = 0;
+        this.status = TaskStatus.ACTIVE;
+        this.priorityIndex = null;
+        this.queue = validQueueIsNull(queue);
+    }
+
+
+    // 도메인 서비스 로직 ----------------------------------------------------------------
+
+
+    public static Task create(String title, TaskQueue queue) {
+        return new Task(title, queue);
+    }
+
+
+    // 행위(도메인 메서드) ----------------------------------------------------------------
+
+
+    public void editTitle(String newTitle) {
+        this.title = normalizeTitle(newTitle);
+    }
+
+    public void editContent(String newContent) {
+        this.content = normalizeContent(newContent);
+    }
+
+    public void setDue(OffsetDateTime dateTime) {
+        this.dueAt = dateTime; // 상태 변경은 별도 dueStatus 로직에 따름
+    }
+
+    public void changeImportance(TaskImportance level) {
+        this.importance = level; // null 허용
+    }
+
+    public void updateProgress(int percent) {
+        if (percent < 0 || percent > 100) throw new IllegalArgumentException("progress must be 0..100");
+        this.progress = percent;
+    }
+
+    public void markCompleted(Clock clock) {
+        this.completedAt = OffsetDateTime.now(validNull(clock, "clock"));
+        this.status = TaskStatus.COMPLETED;
+    }
+
+    public void reopen() {
+        this.completedAt = null;
+        this.status = TaskStatus.ACTIVE;
+    }
+
+    public void moveTask(TaskQueue targetQueue, Long newPriorityIndex) {
+        TaskQueue target = validQueueIsNull(targetQueue);
+        if (!Objects.equals(this.queue.getId(), target.getId())) {
+            throw new IllegalStateException("policy: cross-queue move limited");
+        }
+        this.priorityIndex = newPriorityIndex;
+    }
+
+    public void deferTo(OffsetDateTime dateTime) {
+        if (dateTime == null) throw new IllegalArgumentException("dateTime is null");
+        this.dueAt = dateTime;
+    }
+
+    public void deferDays(int days, Clock clock) {
+        if (days <= 0) throw new IllegalArgumentException("days must be > 0");
+        this.dueAt = Objects.requireNonNullElseGet(this.dueAt, () -> OffsetDateTime.now(validNull(clock, "clock"))).plusDays(days);
+    }
+
+    public void softDelete(Clock clock) {
+        this.status = TaskStatus.TRASHED;
+        this.trashedAt = OffsetDateTime.now(validNull(clock, "clock"));
+    }
+
+
+    /**
+     * 수동 삭제 가능 여부
+     */
+    public boolean canHardDelete(Clock clock) {
+        OffsetDateTime now = OffsetDateTime.now(validNull(clock, "clock"));
+        return this.status == TaskStatus.TRASHED
+                && this.trashedAt != null
+                && !now.isBefore(this.trashedAt);
+    }
+
+    /**
+     * 자동 삭제 가능 여부 - 보존기간이 지난 이후 가능
+     */
+    public boolean canHardDelete(Clock clock, Duration retention) {
+        if (this.status != TaskStatus.TRASHED) return false;
+        OffsetDateTime time = validNull(this.trashedAt, "trashedAt");
+        OffsetDateTime allowedFrom = time.plus(validNull(retention, "retention"));
+        OffsetDateTime now = OffsetDateTime.now(validNull(clock, "clock"));
+        return !now.isBefore(allowedFrom);
+    }
+
+
+    public DueStatus checkDueStatus(OffsetDateTime now, int imminentHours) {
+        if (dueAt == null) return DueStatus.NORMAL;
+        if (now.isAfter(dueAt)) return DueStatus.OVERDUE;
+        OffsetDateTime edge = now.plusHours(imminentHours);
+        return (dueAt.isAfter(now) && !dueAt.isAfter(edge)) ? DueStatus.IMMINENT : DueStatus.NORMAL;
+    }
+
+
+    // 검증 로직 ----------------------------------------------------------------
+
+
+    private static TaskQueue validQueueIsNull(TaskQueue queue) {
+        if (queue == null || queue.getId() == null) throw new IllegalArgumentException("queue is null or transient");
+        return queue;
+    }
+
+    private static <T> T validNull(T value, String name) {
+        if (value == null) throw new IllegalArgumentException(name + " is null");
+        return value;
+    }
+
+    private static String normalizeTitle(String raw) {
+        if (raw == null) throw new IllegalArgumentException("title is null");
+        if (raw.isBlank()) throw new IllegalArgumentException("title is blank");
+        return raw;
+    }
+
+    private static String normalizeContent(String raw) {
+        if (raw == null) return null;
+        if (raw.isBlank()) return null;
+        return raw;
+    }
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/DueStatus.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/DueStatus.java
@@ -1,0 +1,5 @@
+package org.qpeek.qpeek.domain.task.enums;
+
+public enum DueStatus {
+    NORMAL, IMMINENT, OVERDUE
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/TaskImportance.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/TaskImportance.java
@@ -1,0 +1,5 @@
+package org.qpeek.qpeek.domain.task.enums;
+
+public enum TaskImportance {
+    LOW, MID, HIGH
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/TaskStatus.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/TaskStatus.java
@@ -1,0 +1,5 @@
+package org.qpeek.qpeek.domain.task.enums;
+
+public enum TaskStatus {
+    ACTIVE, COMPLETED, OVERDUE, TRASHED
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/TaskTemplateType.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/task/enums/TaskTemplateType.java
@@ -1,0 +1,5 @@
+package org.qpeek.qpeek.domain.task.enums;
+
+public enum TaskTemplateType {
+    FREE, PROBLEM
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/task/entity/TaskTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/task/entity/TaskTest.java
@@ -1,0 +1,482 @@
+package org.qpeek.qpeek.domain.task.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.queue.entity.TaskQueue;
+import org.qpeek.qpeek.domain.task.enums.DueStatus;
+import org.qpeek.qpeek.domain.task.enums.TaskStatus;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+class TaskTest {
+    private static final Clock BASE_CLOCK =
+            Clock.fixed(Instant.parse("2025-08-08T00:00:00Z"), ZoneOffset.UTC);
+
+    private TaskQueue taskQueueWithId(Long id) {
+        TaskQueue mock = Mockito.mock(TaskQueue.class);
+        Mockito.when(mock.getId()).thenReturn(id);
+        return mock;
+    }
+
+
+    // ------------------------------------------------------------------
+    // create()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create() success test")
+    void create_success() {
+        // given
+        TaskQueue queue = taskQueueWithId(1L);
+        String rawTitle = "  Title  With  Spaces  "; // 원문 보존 (trim X)
+
+        // when
+        Task task = Task.create(rawTitle, queue);
+
+        // then
+        assertThat(task.getId()).isNull();
+        assertThat(task.getTitle()).isEqualTo(rawTitle);
+        assertThat(task.getContent()).isNull();
+        assertThat(task.getTemplateType()).isNull();
+        assertThat(task.getImportance()).isNull();
+        assertThat(task.getDueAt()).isNull();
+        assertThat(task.getCompletedAt()).isNull();
+        assertThat(task.getProgress()).isEqualTo(0); // default progress 0
+        assertThat(task.getStatus()).isEqualTo(TaskStatus.ACTIVE); // default status ACTIVE
+        assertThat(task.getPriorityIndex()).isNull();
+        assertThat(task.getQueue()).isEqualTo(queue);
+    }
+
+    @Test
+    @DisplayName("create() fail test : title is null or blank)")
+    void create_fail_title_null() {
+        //given
+        TaskQueue queue = taskQueueWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> Task.create(null, queue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("title is null");
+
+        assertThatThrownBy(() -> Task.create("   ", queue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("title is blank");
+    }
+
+    @Test
+    @DisplayName("create() fail test : queue is null or transient")
+    void create_fail_transient_queue() {
+        //given
+        TaskQueue transientQueue = taskQueueWithId(null);
+
+        //then
+        assertThatThrownBy(() -> Task.create("Task", null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("queue is null or transient");
+
+        assertThatThrownBy(() -> Task.create("Task", transientQueue))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("queue is null or transient");
+    }
+
+
+    // ------------------------------------------------------------------
+    // editTitle() / editContent()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("editTitle() success test")
+    void editTitle_success() {
+        //given
+        Task task = Task.create("Old title", taskQueueWithId(1L));
+        String newTitle = "New  Title";
+
+        //when
+        task.editTitle(newTitle);
+
+        //then
+        assertThat(task.getTitle()).isEqualTo(newTitle);
+    }
+
+    @Test
+    @DisplayName("editTitle() fail test : title is null or blank")
+    void editTitle_fail() {
+        //given
+        Task task = Task.create("Title", taskQueueWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> task.editTitle(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("title is null");
+
+        assertThatThrownBy(() -> task.editTitle("   "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("title is blank");
+    }
+
+    @Test
+    @DisplayName("editContent() normalization")
+    void editContent_normalization() {
+        //given
+        Task task = Task.create("Title", taskQueueWithId(1L));
+
+        // null 유지
+        task.editContent(null); // when
+        assertThat(task.getContent()).isNull(); // then
+
+        // 공백 only → null
+        task.editContent("   \t  "); // when
+        assertThat(task.getContent()).isNull(); // then
+
+        // 원문 보존
+        String c = "  content  ";
+        task.editContent(c); // when
+        assertThat(task.getContent()).isEqualTo(c); // then
+    }
+
+
+    // ------------------------------------------------------------------
+    // setDue()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("setDue() success test")
+    void setDue_success() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+        OffsetDateTime time = OffsetDateTime.now(BASE_CLOCK).plusDays(1);
+
+        //when
+        task.setDue(time);
+
+        //then
+        assertThat(task.getDueAt()).isEqualTo(time);
+    }
+
+
+    // ------------------------------------------------------------------
+    // deferTo(), deferDays()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("deferTo() success test")
+    void deferTo_success() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+        OffsetDateTime time1 = OffsetDateTime.now(BASE_CLOCK).plusDays(1);
+
+        task.setDue(time1);
+        assertThat(task.getDueAt()).isEqualTo(time1);
+
+        OffsetDateTime time2 = time1.plusDays(2);
+        task.deferTo(time2);
+        assertThat(task.getDueAt()).isEqualTo(time2);
+    }
+
+    @Test
+    @DisplayName("deferTo() fail test : dateTime is null")
+    void deferTo_fail_null() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> task.deferTo(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("dateTime is null");
+    }
+
+    @Test
+    @DisplayName("deferDays() success test : dueAt is null")
+    void deferDays_success_null_due() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //when
+        task.deferDays(3, BASE_CLOCK); // dueAt=null 일때, now(clock)+days 로 설정
+
+        //then
+        assertThat(task.getDueAt())
+                .isEqualTo(OffsetDateTime.now(BASE_CLOCK).plusDays(3));
+    }
+
+    @Test
+    @DisplayName("deferDays() success test : dueAt is not null")
+    void deferDays_success_existing_due() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //when
+        OffsetDateTime time = OffsetDateTime.now(BASE_CLOCK).plusDays(1);
+        task.setDue(time);
+
+        task.deferDays(5, null); // clock 미사용 경로
+
+        //then
+        assertThat(task.getDueAt()).isEqualTo(time.plusDays(5));
+    }
+
+    @Test
+    @DisplayName("deferDays() fail test : days<=0 or clock=null")
+    void deferDays_fail() {
+        //when
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> task.deferDays(0, BASE_CLOCK))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("days must be > 0");
+
+        assertThatThrownBy(() -> task.deferDays(-1, BASE_CLOCK))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("days must be > 0");
+
+        assertThatThrownBy(() -> task.deferDays(1, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("clock is null");
+
+    }
+
+
+    // ------------------------------------------------------------------
+    // updateProgress()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("updateProgress() success test")
+    void updateProgress_success() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        task.updateProgress(0); // when
+        assertThat(task.getProgress()).isEqualTo(0); // then
+
+        task.updateProgress(100); // when
+        assertThat(task.getProgress()).isEqualTo(100); // then
+    }
+
+    @Test
+    @DisplayName("updateProgress() fail test : progress is -1, 101")
+    void updateProgress_fail_out_of_range() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> task.updateProgress(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("progress must be 0..100");
+
+        assertThatThrownBy(() -> task.updateProgress(101))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("progress must be 0..100");
+    }
+
+
+    // ------------------------------------------------------------------
+    // updateProgress(), reOpen()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("markCompleted() success test")
+    void markCompleted_success() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        // when
+        task.markCompleted(BASE_CLOCK); // completedAt=now(clock)
+
+        //then
+        assertThat(task.getStatus()).isEqualTo(TaskStatus.COMPLETED);
+        assertThat(task.getCompletedAt())
+                .isEqualTo(OffsetDateTime.now(BASE_CLOCK));
+
+        //when
+        task.reopen(); // reopen() 은 상태 되돌림
+
+        //then
+        assertThat(task.getStatus()).isEqualTo(TaskStatus.ACTIVE);
+        assertThat(task.getCompletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("markCompleted() fail test : clock is null")
+    void markCompleted_fail_null_clock() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> task.markCompleted(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("clock is null");
+    }
+
+
+    // ------------------------------------------------------------------
+    // moveTask()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("moveTask() success test")
+    void moveTask_success() {
+        //given
+        TaskQueue queue = taskQueueWithId(1L);
+        Task task = Task.create("Task Title", queue);
+
+        //when
+        task.moveTask(queue, 10L);
+
+        //then
+        assertThat(task.getPriorityIndex()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("moveTask() fail test : cross-queue move")
+    void moveTask_fail_cross_queue() {
+        //given
+        TaskQueue queue1 = taskQueueWithId(1L);
+        TaskQueue queue2 = taskQueueWithId(2L);
+        Task task = Task.create("Task Title", queue1);
+
+        //then
+        assertThatThrownBy(() -> task.moveTask(queue2, 5L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("policy: cross-queue move limited");
+    }
+
+    @Test
+    @DisplayName("moveTask() fail test : target queue is null or transient")
+    void moveTask_fail_transient_queue() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+        TaskQueue transientQueue = taskQueueWithId(null);
+
+        //then
+        assertThatThrownBy(() -> task.moveTask(null, 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("queue is null or transient");
+
+        assertThatThrownBy(() -> task.moveTask(transientQueue, 1L))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("queue is null or transient");
+    }
+
+
+    // ------------------------------------------------------------------
+    // softDelete() , canHardDelete()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("softDelete() success test")
+    void softDelete_changes_status() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //when
+        task.softDelete(BASE_CLOCK);
+
+        //then
+        assertThat(task.getStatus()).isEqualTo(TaskStatus.TRASHED);
+        assertThat(task.getTrashedAt()).isEqualTo(OffsetDateTime.now(BASE_CLOCK));
+    }
+
+    @Test
+    @DisplayName("canHardDelete(clock) success test")
+    void canHardDelete_withoutRetention_success() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+        assertThat(task.canHardDelete(BASE_CLOCK)).isFalse(); // TaskStatus.ACTIVE 이면 false
+
+        // when
+        task.softDelete(BASE_CLOCK);
+
+        // then
+        assertThat(task.canHardDelete(BASE_CLOCK)).isTrue(); //TaskStatus TRASHED 이면 true
+        assertThat(task.canHardDelete(Clock.offset(BASE_CLOCK, Duration.ofHours(1)))).isTrue(); // 보존시간과 관계 X
+    }
+
+    @Test
+    @DisplayName("canHardDelete(clock, retention) success test")
+    void canHardDelete_withRetention_success() {
+        //given
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+        Duration retention = Duration.ofMinutes(10);
+        assertThat(task.canHardDelete(BASE_CLOCK, retention)).isFalse();
+
+        // when
+        task.softDelete(BASE_CLOCK);
+
+        //then
+        assertThat(task.canHardDelete(BASE_CLOCK, retention)).isFalse(); // 보존기간 전 (false)
+        Clock atBoundary = Clock.fixed(task.getTrashedAt().plus(retention).toInstant(), ZoneOffset.UTC);
+        assertThat(task.canHardDelete(atBoundary, retention)).isTrue(); // 경계: trashedAt + retention (true)
+
+        Clock afterBoundary = Clock.offset(atBoundary, Duration.ofMinutes(1));
+        assertThat(task.canHardDelete(afterBoundary, retention)).isTrue(); // 보존기간 후 (true)
+
+        assertThat(task.canHardDelete(BASE_CLOCK, Duration.ZERO)).isTrue(); // 보존기간 0 = trashed 직후에도 true
+    }
+
+    @Test
+    @DisplayName("canHardDelete() fail test : clock, retention is null")
+    void canHardDelete_withRetention_nulls() {
+        //given
+        Duration retention = Duration.ofMinutes(1);
+        Task task = Task.create("Task Title", taskQueueWithId(1L));
+
+        //when
+        task.softDelete(BASE_CLOCK);
+
+
+        // then
+        assertThatThrownBy(() -> task.canHardDelete(null, retention))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("clock is null");
+
+
+        assertThatThrownBy(() -> task.canHardDelete(BASE_CLOCK, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("retention is null");
+    }
+
+
+    // ------------------------------------------------------------------
+    // checkDueStatus()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("checkDueStatus() success test")
+    void dueStatus_success() {
+        // given
+        OffsetDateTime now = OffsetDateTime.now(BASE_CLOCK);
+        int imminentHours = 3; // 마감 임박 기준
+
+        // when & then - setDue() X
+        Task task1 = Task.create("Task Title", taskQueueWithId(1L));
+        assertThat(task1.checkDueStatus(now, imminentHours)).isEqualTo(DueStatus.NORMAL);
+
+        // when & then - setDue() O
+        Task task2 = Task.create("Task Title", taskQueueWithId(1L));
+
+        // 1) 미래: NORMAL
+        task2.setDue(now.plusHours(10));
+        assertThat(task2.checkDueStatus(now, imminentHours)).isEqualTo(DueStatus.NORMAL);
+
+        // 2) 경계: now + H → IMMINENT
+        task2.setDue(now.plusHours(imminentHours));
+        assertThat(task2.checkDueStatus(now, imminentHours)).isEqualTo(DueStatus.IMMINENT);
+
+        // 3) 윈도우 내부: now + 1h → IMMINENT
+        task2.setDue(now.plusHours(1));
+        assertThat(task2.checkDueStatus(now, imminentHours)).isEqualTo(DueStatus.IMMINENT);
+
+        // 4) 정확히 now → NORMAL
+        task2.setDue(now);
+        assertThat(task2.checkDueStatus(now, imminentHours)).isEqualTo(DueStatus.NORMAL);
+
+        // 5) 과거(마감 초과) → OVERDUE
+        task2.setDue(now.minusMinutes(1));
+        assertThat(task2.checkDueStatus(now, imminentHours)).isEqualTo(DueStatus.OVERDUE);
+    }
+}


### PR DESCRIPTION
### What
- Task Entity 필요 Enums 추가
  - TaskTemplateType : 템플릿 타입
  - TaskImportance : 중요도
  - TaskStatus : Task 상태
  - DueStatus : 현 마감 상태

- Task Entity  추가
- Task Entity Test 추가


### Why
- 작업의 상태/기한/진행 관리 및 수명주기 제어를 위한 도메인 모델과 검증 로직 제공


### Changes
- `domain-task-enums` :
  - TaskTemplateType : 템플릿 타입
  - TaskImportance : 중요도
  - TaskStatus : Task 상태
  - DueStatus : 현 마감 상태

- `domain-task`
  - Task 

### Note
(없음)

### Refs
(없음)
