### PR TITLE
feat/domain-trash

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/trash/entity/TrashItem.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/trash/entity/TrashItem.java
@@ -1,0 +1,123 @@
+package org.qpeek.qpeek.domain.trash.entity;
+
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Check;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.task.entity.Task;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+import static org.qpeek.qpeek.domain.task.enums.TaskStatus.TRASHED;
+
+/**
+ * TrashItem (휴지통 항목)
+ * <p>
+ * <도메인 규칙/정책>
+ * - task: 휴지통에 들어간 작업(필수). 하나의 Task에는 최대 1개의 TrashItem만 존재.
+ * - trashedAt: 휴지통에 들어간 시각(timestamptz). null 불가.
+ * - retentionUntil: 보관 만료 시각(timestamptz). 일반적으로 trashedAt + 보존기간.
+ * - 실제 Task 상태 복구(= ACTIVE 전환)와 TrashItem 삭제는 서비스 계층에서 수행.
+ * - canHardDelete(now): now >= retentionUntil 이면 하드 삭제 수행 가능(실제 삭제는 리포지토리/서비스에서).
+ * <p>
+ * <설계 메모>
+ * - UNIQUE(task_id)로 Task당 1건 보장.
+ * - INDEX(retention_until)로 만료 스캔 최적화, INDEX(trashed_at)로 보관 관리.
+ * - @Check(retention_until >= trashed_at).
+ */
+
+@Entity
+@Getter
+@Table(name = "trash_items",
+        uniqueConstraints = @UniqueConstraint(name = "uk_trash_item_task", columnNames = "task_id"),
+        indexes = {
+                @Index(name = "idx_trash_trashed_at", columnList = "trashed_at"),
+                @Index(name = "idx_trash_retention_until", columnList = "retention_until")
+        })
+@Check(constraints = "retention_until >= trashed_at")
+@ToString(of = {"id", "trashedAt", "retentionUntil"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TrashItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "global_seq_gen")
+    @Column(name = "trash_item_id")
+    private Long id;
+
+    @Column(name = "trashed_at", nullable = false, columnDefinition = "timestamptz")
+    private OffsetDateTime trashedAt;
+
+    @Column(name = "retention_until", nullable = false, columnDefinition = "timestamptz")
+    private OffsetDateTime retentionUntil;
+
+    @JsonIgnore
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "task_id", nullable = false, updatable = false)
+    private Task task;
+
+    private TrashItem(OffsetDateTime trashedAt, OffsetDateTime retentionUntil, Task task) {
+        this.trashedAt = validNonNull(trashedAt, "trashedAt");
+        this.retentionUntil = validNonNull(retentionUntil, "retentionUntil");
+        this.task = validTaskIsNull(task);
+        if (retentionUntil.isBefore(trashedAt)) {
+            throw new IllegalArgumentException("retentionUntil must be >= trashedAt");
+        }
+        if (task.getStatus() != TRASHED) {
+            throw new IllegalStateException("task status must be TRASHED to create TrashItem");
+        }
+    }
+
+
+    // 도메인 서비스 로직 ----------------------------------------------------------------
+
+
+    public static TrashItem create(OffsetDateTime trashedAt, Duration retention, Task task) {
+        if (retention == null || retention.isNegative() || retention.isZero()) {
+            throw new IllegalArgumentException("duration must be > 0");
+        }
+        return new TrashItem(trashedAt, trashedAt.plus(retention), task);
+    }
+
+    public static TrashItem create(OffsetDateTime trashedAt, OffsetDateTime retentionUntil, Task task) {
+        return new TrashItem(trashedAt, retentionUntil, task);
+    }
+
+
+    // 행위(도메인 메서드) ----------------------------------------------------------------
+
+
+    public boolean canHardDelete(OffsetDateTime now) {
+        validNonNull(now, "now");
+        return !now.isBefore(this.retentionUntil);
+    }
+
+    public void extendRetentionUntil(OffsetDateTime newRetentionUntil) {
+        validNonNull(newRetentionUntil, "newRetentionUntil");
+        if (newRetentionUntil.isBefore(this.trashedAt)) {
+            throw new IllegalArgumentException("newRetentionUntil must be >= trashedAt");
+        }
+        if (newRetentionUntil.isAfter(this.retentionUntil)) {
+            this.retentionUntil = newRetentionUntil;
+        }
+    }
+
+
+    // 검증 로직 ----------------------------------------------------------------
+
+
+    private static Task validTaskIsNull(Task task) {
+        if (task == null || task.getId() == null) throw new IllegalArgumentException("task is null or transient");
+        return task;
+    }
+
+    private static <T> T validNonNull(T value, String name) {
+        if (value == null) throw new IllegalArgumentException(name + " is null");
+        return value;
+    }
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/trash/entity/TrashItemTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/trash/entity/TrashItemTest.java
@@ -1,0 +1,239 @@
+package org.qpeek.qpeek.domain.trash.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.task.entity.Task;
+import org.qpeek.qpeek.domain.task.enums.TaskStatus;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+class TrashItemTest {
+    private static final Clock BASE_CLOCK =
+            Clock.fixed(Instant.parse("2025-08-08T00:00:00Z"), ZoneOffset.UTC);
+
+    private Task taskWithIdAndStatus(Long id, TaskStatus status) {
+        Task mock = Mockito.mock(Task.class);
+        Mockito.when(mock.getId()).thenReturn(id);
+        Mockito.when(mock.getStatus()).thenReturn(status);
+        return mock;
+    }
+
+
+    // ------------------------------------------------------------------
+    // create(OffsetDateTime trashedAt, Duration retention, Task task)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create()trashedAt, duration, task) success test")
+    void create_with_duration_success() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        Duration retention = Duration.ofDays(7);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+
+        // when
+        TrashItem trash = TrashItem.create(trashedAt, retention, task);
+
+        // then
+        assertThat(trash.getId()).isNull();
+        assertThat(trash.getTrashedAt()).isEqualTo(trashedAt);
+        assertThat(trash.getRetentionUntil()).isEqualTo(trashedAt.plus(retention));
+        assertThat(trash.getTask()).isEqualTo(task);
+    }
+
+    @Test
+    @DisplayName("create(trashedAt, duration, task) fail test : duration <= 0 or null")
+    void create_with_duration_fail_invalid_duration() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+
+        // then
+        assertThatThrownBy(() -> TrashItem.create(trashedAt, Duration.ZERO, task))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be > 0");
+
+        assertThatThrownBy(() -> TrashItem.create(trashedAt, Duration.ofSeconds(-1), task))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("duration must be > 0");
+    }
+
+
+    // ------------------------------------------------------------------
+    // create(OffsetDateTime trashedAt, OffsetDateTime retentionUntil, Task task)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create(trashedAt, retentionUntil, task) success test")
+    void create_with_retentionUntil_success() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.plusDays(3);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+
+        // when
+        TrashItem trash = TrashItem.create(trashedAt, retentionUntil, task);
+
+        // then
+        assertThat(trash.getTrashedAt()).isEqualTo(trashedAt);
+        assertThat(trash.getRetentionUntil()).isEqualTo(retentionUntil);
+        assertThat(trash.getTask()).isEqualTo(task);
+    }
+
+    @Test
+    @DisplayName("create(trashedAt, retentionUntil, task) fail test : trashedAt is null")
+    void create_with_retentionUntil_fail_trashedAt_null() {
+        // given
+        OffsetDateTime retentionUntil = OffsetDateTime.now(BASE_CLOCK).plusDays(7);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+
+        // then
+        assertThatThrownBy(() -> TrashItem.create(null, retentionUntil, task))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("trashedAt is null");
+    }
+
+    @Test
+    @DisplayName("create(trashedAt, retentionUntil, task) fail test : retentionUntil < trashedAt")
+    void create_with_retentionUntil_fail_order_violation() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.minusMinutes(1);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+
+        // then
+        assertThatThrownBy(() -> TrashItem.create(trashedAt, retentionUntil, task))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("retentionUntil must be >= trashedAt");
+    }
+
+    @Test
+    @DisplayName("create( fail test : task is null or transient")
+    void create_fail_transient_task() {
+        // given
+        Task transientTask = taskWithIdAndStatus(null, TaskStatus.TRASHED);
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.plusDays(1);
+
+        // then
+        assertThatThrownBy(() -> TrashItem.create(trashedAt, retentionUntil, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("task is null or transient");
+
+        assertThatThrownBy(() -> TrashItem.create(trashedAt, retentionUntil, transientTask))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("task is null or transient");
+    }
+
+    @Test
+    @DisplayName("create() fail test : task status is not TRASHED")
+    void create_fail_task_status_not_trashed() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.plusDays(1);
+        Task nonTrashedTask = taskWithIdAndStatus(1L, TaskStatus.ACTIVE);
+
+        // then
+        assertThatThrownBy(() -> TrashItem.create(trashedAt, retentionUntil, nonTrashedTask))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("task status must be TRASHED to create TrashItem");
+    }
+
+
+    // ------------------------------------------------------------------
+    // canHardDelete()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("canHardDelete() success test")
+    void canHardDelete_success() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.plusHours(2);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+        TrashItem trash = TrashItem.create(trashedAt, retentionUntil, task);
+
+        // then
+        assertThat(trash.canHardDelete(retentionUntil.minusMinutes(1))).isFalse(); // before
+        assertThat(trash.canHardDelete(retentionUntil)).isTrue();                  // boundary
+        assertThat(trash.canHardDelete(retentionUntil.plusSeconds(1))).isTrue();  // after
+    }
+
+    @Test
+    @DisplayName("canHardDelete(now) fail test : now is null")
+    void canHardDelete_fail_null() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+        TrashItem trash = TrashItem.create(trashedAt, trashedAt.plusDays(1), task);
+
+        // then
+        assertThatThrownBy(() -> trash.canHardDelete(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("now is null");
+    }
+
+
+    // ------------------------------------------------------------------
+    // extendRetentionUntil()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("extendRetentionUntil() success test")
+    void extendRetentionUntil_success() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.plusDays(7);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+        TrashItem trash = TrashItem.create(trashedAt, retentionUntil, task);
+
+        OffsetDateTime later = retentionUntil.plusDays(3);
+
+        // when
+        trash.extendRetentionUntil(later);
+
+        // then
+        assertThat(trash.getRetentionUntil()).isEqualTo(later);
+    }
+
+    @Test
+    @DisplayName("extendRetentionUntil() success test : Retention until not be changed when newRetention is not later")
+    void extendRetentionUntil_success_no_change_when_not_later() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.plusDays(7);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+        TrashItem trash = TrashItem.create(trashedAt, retentionUntil, task);
+
+        OffsetDateTime earlierButAfterTrashed = retentionUntil.minusDays(1);
+
+        // when
+        trash.extendRetentionUntil(retentionUntil);
+        assertThat(trash.getRetentionUntil()).isEqualTo(retentionUntil);
+
+        trash.extendRetentionUntil(earlierButAfterTrashed);
+        assertThat(trash.getRetentionUntil()).isEqualTo(retentionUntil);
+    }
+
+    @Test
+    @DisplayName("extendRetentionUntil(newRetentionUntil) fail test : New retention is null or before trashedAt")
+    void extendRetentionUntil_fail_invalid() {
+        // given
+        OffsetDateTime trashedAt = OffsetDateTime.now(BASE_CLOCK);
+        OffsetDateTime retentionUntil = trashedAt.plusDays(2);
+        Task task = taskWithIdAndStatus(1L, TaskStatus.TRASHED);
+        TrashItem trash = TrashItem.create(trashedAt, retentionUntil, task);
+
+        // then
+        assertThatThrownBy(() -> trash.extendRetentionUntil(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("newRetentionUntil is null");
+
+        assertThatThrownBy(() -> trash.extendRetentionUntil(trashedAt.minusSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("newRetentionUntil must be >= trashedAt");
+    }
+}


### PR DESCRIPTION
### What
- TrashItem Entity  추가
- TrashItem Entity Test 추가


### Why
- TRASHED 상태가 된 작업의 보관 기간 및 휴지통 옮겨진 시간 데이터 관리 용도 


### Changes
- `domain-trash` :
    - TaskTrashItem 
    - TaskTrashItemTest


### Note
(없음)

### Refs
(없음)
