### PR TITLE
feat/domain-log

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/log/entity/TaskHardDeleteLog.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/log/entity/TaskHardDeleteLog.java
@@ -1,0 +1,94 @@
+package org.qpeek.qpeek.domain.log.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Check;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.task.entity.Task;
+import org.qpeek.qpeek.domain.trash.entity.TrashItem;
+
+import java.time.OffsetDateTime;
+
+/**
+ * TaskHardDeleteLog (작업 하드 삭제 이력)
+ * <p>
+ * <도메인 규칙/정책>
+ * - taskId: 삭제된 Task의 식별자(원시 값). 실제 Task 행은 이미 삭제되었을 수 있어 FK 미사용.
+ * - trashedAt: 해당 Task가 휴지통으로 이동된 시각.
+ * - hardDeletedAt: 실제 하드 삭제가 완료된 시각(로그 시각).
+ * <p>
+ * <설계 메모>
+ * - 조회 최적화를 위해 taskId / hardDeletedAt 인덱스 구성.
+ * - 무결성 제약: hard_deleted_at >= trashed_at.
+ * - 로그 테이블이므로 UPDATE 최소화(대부분 INSERT-only).
+ * - 보존 기간(retention) 정책 증빙이 필요 없다면 단순히 trashedAt과 hardDeletedAt만 기록.
+ * (정책 추적이 필요하면 별도 테이블/정책 버전으로 관리)
+ */
+@Entity
+@Getter
+@Table(name = "task_hard_delete_logs",
+        indexes = {
+                @Index(name = "idx_delete_log_task_id", columnList = "task_id"),
+                @Index(name = "idx_delete_log_hard_deleted_at", columnList = "hard_deleted_at")
+        })
+@Check(constraints = "hard_deleted_at >= trashed_at")
+@ToString(of = {"id", "taskId", "hardDeletedAt"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TaskHardDeleteLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "global_seq_gen")
+    @Column(name = "task_hard_delete_log_id")
+    private Long id;
+
+    @Column(name = "task_id", nullable = false)
+    private Long taskId;
+
+    @Column(name = "trashed_at", nullable = false, columnDefinition = "timestamptz")
+    private OffsetDateTime trashedAt;
+
+    @Column(name = "hard_deleted_at", nullable = false, updatable = false, columnDefinition = "timestamptz")
+    private OffsetDateTime hardDeletedAt;
+
+    private TaskHardDeleteLog(Long taskId,
+                              OffsetDateTime trashedAt,
+                              OffsetDateTime hardDeletedAt) {
+        this.taskId = requireNonNull(taskId, "taskId");
+        this.trashedAt = requireNonNull(trashedAt, "trashedAt");
+        this.hardDeletedAt = requireNonNull(hardDeletedAt, "hardDeletedAt");
+
+        if (hardDeletedAt.isBefore(trashedAt)) {
+            throw new IllegalArgumentException("hardDeletedAt must be >= trashedAt");
+        }
+    }
+
+    // 도메인 생성 로직 -----------------------------------------------------------
+
+    public static TaskHardDeleteLog createFromTrashItem(TrashItem trashItem, OffsetDateTime hardDeletedAt) {
+        requireNonNull(trashItem, "trashItem");
+        requireNonNull(hardDeletedAt, "hardDeletedAt");
+
+        Task task = requireNonNull(trashItem.getTask(), "task");
+        Long taskId = requireNonNull(task.getId(), "taskId");
+
+        OffsetDateTime trashedAt = requireNonNull(trashItem.getTrashedAt(), "trashedAt");
+
+        return new TaskHardDeleteLog(taskId, trashedAt, hardDeletedAt);
+    }
+
+    public static TaskHardDeleteLog create(Long taskId,
+                                           OffsetDateTime trashedAt,
+                                           OffsetDateTime hardDeletedAt) {
+        return new TaskHardDeleteLog(taskId, trashedAt, hardDeletedAt);
+    }
+
+    // 공통 검증 ---------------------------------------------------------------
+
+    private static <T> T requireNonNull(T value, String name) {
+        if (value == null) throw new IllegalArgumentException(name + " is null");
+        return value;
+    }
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/log/entity/TaskHardDeleteLogTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/log/entity/TaskHardDeleteLogTest.java
@@ -1,0 +1,163 @@
+package org.qpeek.qpeek.domain.log.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.task.entity.Task;
+import org.qpeek.qpeek.domain.trash.entity.TrashItem;
+
+import java.time.*;
+
+import static org.assertj.core.api.Assertions.*;
+
+class TaskHardDeleteLogTest {
+
+    private final OffsetDateTime trashedAt = OffsetDateTime.parse("2025-08-08T00:00:00Z");
+    private final OffsetDateTime hardDeleted = trashedAt.plusDays(1);
+
+    private TrashItem trashItemWithTask(Long taskId, OffsetDateTime trashedAt) {
+        Task taskMock = Mockito.mock(Task.class);
+        Mockito.when(taskMock.getId()).thenReturn(taskId);
+
+        TrashItem trashItemMock = Mockito.mock(TrashItem.class);
+        Mockito.when(trashItemMock.getTask()).thenReturn(taskMock);
+        Mockito.when(trashItemMock.getTrashedAt()).thenReturn(trashedAt);
+        return trashItemMock;
+    }
+
+    // ------------------------------------------------------------------
+    // createFromTrashItem()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createFromTrashItem() success test")
+    void createFromTrashItem_success() {
+        // given
+        Long taskId = 1L;
+        TrashItem trashItem = trashItemWithTask(taskId, trashedAt);
+
+        // when
+        TaskHardDeleteLog log = TaskHardDeleteLog.createFromTrashItem(trashItem, hardDeleted);
+
+        // then
+        assertThat(log.getTaskId()).isEqualTo(taskId);
+        assertThat(log.getTrashedAt()).isEqualTo(trashedAt);
+        assertThat(log.getHardDeletedAt()).isEqualTo(hardDeleted);
+    }
+
+    @Test
+    @DisplayName("createFromTrashItem() fail test : trashItem is null")
+    void createFromTrashItem_fail_null_item() {
+        //then
+        assertThatThrownBy(() -> TaskHardDeleteLog.createFromTrashItem(null, hardDeleted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("trashItem is null");
+    }
+
+    @Test
+    @DisplayName("createFromTrashItem() fail test : hardDeletedAt is null")
+    void createFromTrashItem_fail_null_hardDeletedAt() {
+        //given
+        TrashItem trashItem = trashItemWithTask(1L, trashedAt);
+
+        //then
+        assertThatThrownBy(() -> TaskHardDeleteLog.createFromTrashItem(trashItem, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("hardDeletedAt is null");
+    }
+
+    @Test
+    @DisplayName("createFromTrashItem() fail test : task is null")
+    void createFromTrashItem_fail_null_task() {
+        //given
+        TrashItem trashItem = Mockito.mock(TrashItem.class);
+        Mockito.when(trashItem.getTask()).thenReturn(null);
+        Mockito.when(trashItem.getTrashedAt()).thenReturn(trashedAt);
+
+        //then
+        assertThatThrownBy(() -> TaskHardDeleteLog.createFromTrashItem(trashItem, hardDeleted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("task is null");
+    }
+
+    @Test
+    @DisplayName("createFromTrashItem() fail test : task is transient")
+    void createFromTrashItem_fail_transient_task() {
+        //given
+        Task transientTask = Mockito.mock(Task.class);
+        Mockito.when(transientTask.getId()).thenReturn(null);
+
+        TrashItem trashItem = Mockito.mock(TrashItem.class);
+        Mockito.when(trashItem.getTask()).thenReturn(transientTask);
+        Mockito.when(trashItem.getTrashedAt()).thenReturn(trashedAt);
+
+        //then
+        assertThatThrownBy(() -> TaskHardDeleteLog.createFromTrashItem(trashItem, hardDeleted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("taskId is null");
+    }
+
+    @Test
+    @DisplayName("createFromTrashItem() fail test : trashedAt is null")
+    void createFromTrashItem_fail_null_trashedAt_from_item() {
+        //given
+        TrashItem trashItem = trashItemWithTask(1L, null);
+
+        //then
+        assertThatThrownBy(() -> TaskHardDeleteLog.createFromTrashItem(trashItem, hardDeleted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("trashedAt is null");
+    }
+
+
+    // ------------------------------------------------------------------
+    // create()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("create() success test")
+    void create_success() {
+        //when
+        TaskHardDeleteLog log = TaskHardDeleteLog.create(1L, trashedAt, hardDeleted);
+
+        //then
+        assertThat(log.getTaskId()).isEqualTo(1L);
+        assertThat(log.getTrashedAt()).isEqualTo(trashedAt);
+        assertThat(log.getHardDeletedAt()).isEqualTo(hardDeleted);
+    }
+
+    @Test
+    @DisplayName("create() success test : hardDeletedAt == trashedAt")
+    void create_success_equal_boundary() {
+        //when
+        TaskHardDeleteLog log = TaskHardDeleteLog.create(1L, trashedAt, trashedAt);
+
+        //then
+        assertThat(log.getHardDeletedAt()).isEqualTo(trashedAt);
+    }
+
+    @Test
+    @DisplayName("create() fail test: hardDeletedAt < trashedAt")
+    void create_fail_hardDeleted_before_trashed() {
+        assertThatThrownBy(() -> TaskHardDeleteLog.create(1L, trashedAt, trashedAt.minusSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("hardDeletedAt must be >= trashedAt");
+    }
+
+    @Test
+    @DisplayName("create() fail test : null arguments (taskId/trashedAt/hardDeletedAt)")
+    void create_fail_null_arguments() {
+        //then
+        assertThatThrownBy(() -> TaskHardDeleteLog.create(null, trashedAt, hardDeleted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("taskId is null");
+
+        assertThatThrownBy(() -> TaskHardDeleteLog.create(1L, null, hardDeleted))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("trashedAt is null");
+
+        assertThatThrownBy(() -> TaskHardDeleteLog.create(1L, trashedAt, null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("hardDeletedAt is null");
+    }
+}


### PR DESCRIPTION
### What
- TaskHardDeleteLog Entity  추가
- TaskHardDeleteLog Entity Test 추가


### Why
- 휴지통으로 넘어간 Task 완전 삭제 로그 용도 


### Changes
- `domain-log` :
    - TaskHardDeleteLog
    - TaskHardDeleteLogTest


### Note
(없음)

### Refs
(없음)
