### PR TITLE
feat/domain-notification

### DIFF
--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/notification/entity/Notification.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/notification/entity/Notification.java
@@ -1,0 +1,147 @@
+package org.qpeek.qpeek.domain.notification.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.hibernate.annotations.Check;
+import org.qpeek.qpeek.common.entity.BaseEntity;
+import org.qpeek.qpeek.domain.member.entity.Member;
+import org.qpeek.qpeek.domain.notification.enums.NotificationChannelType;
+import org.qpeek.qpeek.domain.notification.enums.NotificationType;
+import org.qpeek.qpeek.domain.task.entity.Task;
+
+import java.time.Clock;
+import java.time.OffsetDateTime;
+
+/**
+ * Notification (알림 이벤트)
+ * <p>
+ * <도메인 규칙/정책>
+ * - member: 알림 대상 회원(필수). 생성 후 변경 불가(updatable=false).
+ * - task: 관련 작업(선택). report 타입 등은 null 가능. 생성 후 변경 불가(updatable=false).
+ * - type: D-1 / IMMINENT / DUE / OVERDUE / REPORT 등 알림 유형.
+ * - channel: EMAIL / KAKAO / SLACK / WEBPUSH 등 발송 채널.
+ * - scheduledAt: 발송 예정 시각(timestamptz). null 불가.
+ * - sentAt: 실제 발송 시각(timestamptz). null이면 아직 미발송 상태.
+ * <설계 메모>
+ * - 인덱스: (scheduled_at), (member_id, scheduled_at), (task_id), (sent_at) 권장.
+ * - 무결성: sent_at >= scheduled_at 또는 sent_at IS NULL 보장(@Check).
+ */
+@Entity
+@Getter
+@Table(name = "notifications",
+        indexes = {
+                @Index(name = "idx_notifications_scheduled_at", columnList = "scheduled_at"),
+                @Index(name = "idx_notifications_member_scheduled", columnList = "member_id, scheduled_at"),
+                @Index(name = "idx_notifications_task", columnList = "task_id"),
+                @Index(name = "idx_notifications_sent_at", columnList = "sent_at")
+        })
+@Check(constraints = "sent_at IS NULL OR sent_at >= scheduled_at")
+@ToString(of = {"id", "type", "channel", "scheduledAt", "sentAt"})
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "global_seq_gen")
+    @Column(name = "notification_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 20)
+    private NotificationType type;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "channel", nullable = false, length = 20)
+    private NotificationChannelType channel;
+
+    @Column(name = "scheduled_at", nullable = false, columnDefinition = "timestamptz")
+    private OffsetDateTime scheduledAt;
+
+    @Column(name = "sent_at", columnDefinition = "timestamptz")
+    private OffsetDateTime sentAt;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "member_id", nullable = false, updatable = false)
+    private Member member;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "task_id", updatable = false)
+    private Task task;
+
+    private Notification(NotificationType type, NotificationChannelType channel, OffsetDateTime scheduledAt, Member member, Task task) {
+        this.type = validNullOrBlank(type, "type");
+        this.channel = validNullOrBlank(channel, "channel");
+        this.scheduledAt = validNullOrBlank(scheduledAt, "scheduledAt");
+        this.sentAt = null;
+        this.member = validMemberIsNull(member);
+        this.task = validTaskIsNull(task);
+    }
+
+    // 도메인 서비스 로직 ----------------------------------------------------------------
+
+
+    public static Notification schedule(NotificationType type, NotificationChannelType channel, OffsetDateTime scheduledAt, Member member) {
+        return new Notification(type, channel, scheduledAt, member, null);
+    }
+
+    public static Notification scheduleForTask(NotificationType type, NotificationChannelType channel, OffsetDateTime scheduledAt, Member member, Task task) {
+        return new Notification(type, channel, scheduledAt, member, task);
+    }
+
+
+    // 행위(도메인 메서드) ----------------------------------------------------------------
+
+
+    /**
+     * now 기준 발송 가능 여부
+     */
+    public boolean canSend(OffsetDateTime now) {
+        validNullOrBlank(now, "now");
+        return sentAt == null && !now.isBefore(scheduledAt); // now >= scheduledAt
+    }
+
+    /**
+     * 발송 처리
+     */
+    public void markSent(Clock clock) {
+        validNullOrBlank(clock, "clock");
+        this.sentAt = OffsetDateTime.now(clock);
+    }
+
+    /**
+     * 재스케줄(미발송 상태에서만 허용)
+     */
+    public void reschedule(OffsetDateTime newTime) {
+        if (this.sentAt != null) throw new IllegalStateException("already sent");
+        this.scheduledAt = validNullOrBlank(newTime, "scheduledAt");
+    }
+
+
+    // 검증 로직 ----------------------------------------------------------------
+
+
+    private static Member validMemberIsNull(Member member) {
+        if (member == null || member.getId() == null)
+            throw new IllegalArgumentException("member is null or transient");
+        return member;
+    }
+
+    private static Task validTaskIsNull(Task task) {
+        if (task == null) return null;
+        if (task.getId() == null)
+            throw new IllegalArgumentException("task is transient");
+        return task;
+    }
+
+    private static <T> T validNullOrBlank(T value, String name) {
+        if (value == null) throw new IllegalArgumentException(name + " is null");
+        if (value instanceof CharSequence cs && cs.toString().isBlank())
+            throw new IllegalArgumentException(name + " is blank");
+        return value;
+    }
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/notification/enums/NotificationChannelType.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/notification/enums/NotificationChannelType.java
@@ -1,0 +1,8 @@
+package org.qpeek.qpeek.domain.notification.enums;
+
+public enum NotificationChannelType {
+    EMAIL,
+    KAKAO,
+    SLACK,
+    WEBPUSH
+}

--- a/qpeek/src/main/java/org/qpeek/qpeek/domain/notification/enums/NotificationType.java
+++ b/qpeek/src/main/java/org/qpeek/qpeek/domain/notification/enums/NotificationType.java
@@ -1,0 +1,9 @@
+package org.qpeek.qpeek.domain.notification.enums;
+
+public enum NotificationType {
+    BEFORE_DAY,   // D-1
+    IMMINENT,    // 임박(N시간 전)
+    DUE,         // 마감 시각
+    OVERDUE,     // 초과
+    REPORT       // 데일리 클로징 보고
+}

--- a/qpeek/src/test/java/org/qpeek/qpeek/domain/notification/entity/NotificationTest.java
+++ b/qpeek/src/test/java/org/qpeek/qpeek/domain/notification/entity/NotificationTest.java
@@ -1,0 +1,326 @@
+package org.qpeek.qpeek.domain.notification.entity;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qpeek.qpeek.domain.member.entity.Member;
+import org.qpeek.qpeek.domain.notification.enums.NotificationChannelType;
+import org.qpeek.qpeek.domain.notification.enums.NotificationType;
+import org.qpeek.qpeek.domain.task.entity.Task;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+class NotificationTest {
+    private final OffsetDateTime scheduledAt = OffsetDateTime.parse("2025-08-08T00:00:00Z");
+    private final OffsetDateTime beforeScheduled = scheduledAt.minusMinutes(5);
+    private final OffsetDateTime afterScheduled = scheduledAt.plusMinutes(30);
+
+    private Member memberWithId(Long id) {
+        Member mock = Mockito.mock(Member.class);
+        Mockito.when(mock.getId()).thenReturn(id);
+        return mock;
+    }
+
+    private Task taskWithId(Long id) {
+        Task mock = Mockito.mock(Task.class);
+        Mockito.when(mock.getId()).thenReturn(id);
+        return mock;
+    }
+
+    // ------------------------------------------------------------------
+    // schedule()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("schedule() success test")
+    void schedule_success() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, member);
+
+        // then
+        assertThat(notification.getId()).isNull();
+        assertThat(notification.getType()).isEqualTo(NotificationType.DUE);
+        assertThat(notification.getChannel()).isEqualTo(NotificationChannelType.EMAIL);
+        assertThat(notification.getScheduledAt()).isEqualTo(scheduledAt);
+        assertThat(notification.getSentAt()).isNull();
+        assertThat(notification.getMember()).isEqualTo(member);
+        assertThat(notification.getTask()).isNull();
+    }
+
+    @Test
+    @DisplayName("schedule() fail test : null arguments")
+    void schedule_fail_null_arguments() {
+        //given
+        Member member = memberWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> Notification.schedule(null, NotificationChannelType.EMAIL, scheduledAt, member)) // type
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("type is null");
+
+        assertThatThrownBy(() -> Notification.schedule(NotificationType.DUE, null, scheduledAt, member)) // channel
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("channel is null");
+
+        assertThatThrownBy(() -> Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, null, member)) // scheduledAt
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("scheduledAt is null");
+
+        assertThatThrownBy(() -> Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, null)) // member
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+    }
+
+    @Test
+    @DisplayName("schedule() fail test : member is transient")
+    void schedule_fail_transient_member() {
+        // given
+        Member transientMember = memberWithId(null);
+
+        // then
+        assertThatThrownBy(() -> Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, transientMember))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+    }
+
+
+    // ------------------------------------------------------------------
+    // scheduleForTask()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("scheduleForTask() success test")
+    void scheduleForTask_success() {
+        // given
+        Member member = memberWithId(1L);
+        Task task = taskWithId(1L);
+
+        // when
+        Notification notification = Notification.scheduleForTask(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, member, task);
+
+        // then
+        assertThat(notification.getMember()).isEqualTo(member);
+        assertThat(notification.getTask()).isEqualTo(task);
+        assertThat(notification.getScheduledAt()).isEqualTo(scheduledAt);
+        assertThat(notification.getSentAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("scheduleForTask() success test : task is null")
+    void scheduleForTask_success_task_null() {
+        // given
+        Member member = memberWithId(1L);
+
+        // when
+        Notification notification = Notification.scheduleForTask(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, member, null);
+
+        // then
+        assertThat(notification.getTask()).isNull();
+    }
+
+    @Test
+    @DisplayName("scheduleForTask() fail test : member and task is null or transient")
+    void scheduleForTask_fail_transient_member_and_task() {
+        Member transientMember = memberWithId(null);
+        Task transientTask = taskWithId(null);
+        Member member = memberWithId(1L);
+
+        assertThatThrownBy(() ->
+                Notification.scheduleForTask(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, transientMember, taskWithId(1L)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("member is null or transient");
+
+        assertThatThrownBy(() ->
+                Notification.scheduleForTask(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, member, transientTask))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("task is transient");
+    }
+
+    @Test
+    @DisplayName("scheduleForTask() fail test : null arguments")
+    void scheduleForTask_fail_null_arguments() {
+        //given
+        Member member = memberWithId(1L);
+        Task task = taskWithId(1L);
+
+        //then
+        assertThatThrownBy(() -> Notification.scheduleForTask(null, NotificationChannelType.EMAIL, scheduledAt, member, task)) // type
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("type is null");
+
+        assertThatThrownBy(() -> Notification.scheduleForTask(NotificationType.DUE, null, scheduledAt, member, task)) // channel
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("channel is null");
+
+        assertThatThrownBy(() -> Notification.scheduleForTask(NotificationType.DUE, NotificationChannelType.EMAIL, null, member, task)) // scheduledAt
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("scheduledAt is null");
+    }
+
+
+    // ------------------------------------------------------------------
+    // canSend(now)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("canSend() success test : now == scheduledAt")
+    void canSend_success_equal_boundary() {
+        //when
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+
+        //then
+        assertThat(notification.canSend(scheduledAt)).isTrue();
+    }
+
+    @Test
+    @DisplayName("canSend() success test : now > scheduledAt")
+    void canSend_success_after() {
+        //when
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+
+        //then
+        assertThat(notification.canSend(afterScheduled)).isTrue();
+    }
+
+    @Test
+    @DisplayName("canSend() success test : now < scheduledAt")
+    void canSend_success_before() {
+        //when
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+
+        //then
+        assertThat(notification.canSend(beforeScheduled)).isFalse();
+    }
+
+    @Test
+    @DisplayName("canSend() fail test : now is null")
+    void canSend_fail_now_null() {
+        //when
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> notification.canSend(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("now is null");
+    }
+
+    @Test
+    @DisplayName("canSend() fail test : after markSent()")
+    void canSend_false_after_sent() {
+        //given
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+        Clock clock = Clock.fixed(afterScheduled.toInstant(), ZoneOffset.UTC);
+
+        //when
+        notification.markSent(clock);
+
+        //then
+        assertThat(notification.getSentAt()).isEqualTo(OffsetDateTime.ofInstant(afterScheduled.toInstant(), ZoneOffset.UTC));
+        assertThat(notification.canSend(afterScheduled.plusMinutes(1))).isFalse();
+    }
+
+
+    // ------------------------------------------------------------------
+    // markSent(clock)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("markSent() success test : sentAt == now(clock)")
+    void markSent_success() {
+        //given
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+        Instant sendInstant = afterScheduled.toInstant();
+        Clock clock = Clock.fixed(sendInstant, ZoneOffset.UTC);
+
+        //when
+        notification.markSent(clock);
+
+
+        //then
+        assertThat(notification.getSentAt()).isEqualTo(OffsetDateTime.ofInstant(sendInstant, ZoneOffset.UTC));
+    }
+
+    @Test
+    @DisplayName("markSent() fail test : clock is null")
+    void markSent_fail_null_clock() {
+        //when
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> notification.markSent(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("clock is null");
+    }
+
+
+    // ------------------------------------------------------------------
+    // reschedule(newTime)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("reschedule() success test")
+    void reschedule_success() {
+        //given
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+        OffsetDateTime newTime = scheduledAt.plusHours(2);
+
+        //when
+        notification.reschedule(newTime);
+
+        //then
+        assertThat(notification.getScheduledAt()).isEqualTo(newTime);
+        assertThat(notification.getSentAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("reschedule() success test")
+    void reschedule_success_past_allowed() {
+        //given
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+        OffsetDateTime earlier = scheduledAt.minusHours(1);
+
+        //when
+        notification.reschedule(earlier);
+
+        //then
+        assertThat(notification.getScheduledAt()).isEqualTo(earlier);
+    }
+
+    @Test
+    @DisplayName("reschedule() fail test : already sent")
+    void reschedule_fail_already_sent() {
+        //given
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+        Clock clock = Clock.fixed(afterScheduled.toInstant(), ZoneOffset.UTC);
+
+        //when
+        notification.markSent(clock);
+
+        // then
+        assertThatThrownBy(() -> notification.reschedule(afterScheduled.plusHours(1)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("already sent");
+    }
+
+    @Test
+    @DisplayName("reschedule() fail test : newTime is null")
+    void reschedule_fail_null_new_time() {
+        //when
+        Notification notification = Notification.schedule(NotificationType.DUE, NotificationChannelType.EMAIL, scheduledAt, memberWithId(1L));
+
+        //then
+        assertThatThrownBy(() -> notification.reschedule(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("scheduledAt is null");
+    }
+}


### PR DESCRIPTION
### What
- NotificationChannelType Enum  추가
- NotificationType Enum 추가

- Notification Entity 추가
- Notification Entity Test 추가


### Why
- 알림을 언제,누구에게,어떤 유형,어떤 채널로 보낼지 스케줄링하고, 발송 상태를 기록 관리하는 용도


### Changes
- `domain-notification-enums` :
    - NotificationChannelType
    - NotificationType

- `domain-notification` :
  - Notification
  - NotificationTest

### Note
(없음)

### Refs
(없음)
